### PR TITLE
Fix SWF loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-test
+# Frutiparc
+
+This repository hosts a small server used to serve the assets of the
+**Frutiparc** Flash game.  The game expects to communicate with a web
+server running on `localhost:8888`.
+
+## Running the game
+
+1. Install the dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the HTTP server (defaults to port `8888`):
+   ```bash
+   npm start
+   ```
+   You can change the port by setting the `PORT` environment variable if
+   necessary.
+3. Open your browser at [`http://localhost:8888/index.html`](http://localhost:8888/index.html).
+   The page uses [Ruffle](https://ruffle.rs/) to load `main.swf`.
+
+If everything is accessible, the progress bar shown by `main.swf` will
+continue past 10 % and the game will start.

--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,8 @@
    <object id="frutiparc-swf" data="main.swf" width="1024" height="768">
 
 
-        <param name="flashvars" value="sid=debug&domain=localhost" />
+        <!-- The Flash client expects the domain to include a trailing slash -->
+        <param name="flashvars" value="sid=debug&domain=localhost/" />
     </object>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -3,7 +3,10 @@ const { WebSocketServer } = require('ws');
 const path = require('path');
 
 const app = express();
-const port = process.env.PORT || 3000;
+// The original game expects the HTTP server to run on port 8888.
+// We keep the ability to override via the PORT environment variable
+// but default to 8888 so that `npm start` works out of the box.
+const port = process.env.PORT || 8888;
 
 // Serve static files
 app.use(express.static(path.join(__dirname, 'public')));


### PR DESCRIPTION
## Summary
- default the server to port 8888
- document how to start the HTTP server
- include trailing slash for the domain parameter in the example HTML

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840b643d9948320bd11985ef96a7add