### PR TITLE
Fix fileIcon loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ server running on `localhost:8888`.
    You can change the port by setting the `PORT` environment variable if
    necessary.
 3. Open your browser at [`http://localhost:8888/index.html`](http://localhost:8888/index.html).
-   The page uses [Ruffle](https://ruffle.rs/) to load `main.swf`.
+   The page uses [Ruffle](https://ruffle.rs/) to load `main.swf`.  The
+   `flashvars` parameter in `public/index.html` already sets
+   `domain=localhost:8888/` so that the additional assets (e.g.
+   `fileIcon.swf`) are loaded from the same server.
 
 If everything is accessible, the progress bar shown by `main.swf` will
 continue past 10 % and the game will start.

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
 
 
         <!-- The Flash client expects the domain to include a trailing slash -->
-        <param name="flashvars" value="sid=debug&domain=localhost/" />
+        <param name="flashvars" value="sid=debug&domain=localhost:8888/" />
     </object>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- serve game assets from localhost:8888 by default
- document the `domain` setting in README

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_684154ad9d5c8320ac817ff9868b17cb