### PR TITLE
Add AS2 migration plan and tooling (inventory, Lot A selector, docs, MVP runner)

### DIFF
--- a/MIGRATION_PLAN.md
+++ b/MIGRATION_PLAN.md
@@ -1,0 +1,94 @@
+# Plan de modernisation de Frutiparc (Flash 2003-2004)
+
+Ce dépôt contient un code ActionScript 2 / Flash historique. Le plus sûr est une **migration progressive**, avec un objectif de compatibilité fonctionnelle avant toute refonte UX.
+
+## Recommandation courte
+
+- **Front-end**: TypeScript + moteur 2D web (PixiJS) pour remplacer l’affichage Flash.
+- **Back-end**: Node.js (NestJS ou Fastify) pour services, sessions, API.
+- **Option haxe**: utile si vous voulez conserver une logique proche d’AS2 et cibler JS avec moins de réécriture initiale.
+
+👉 En pratique, un bon compromis est:
+1. Convertir/porter la logique métier la plus sensible en **Haxe** (si le code AS2 est dense et fragile).
+2. Exposer cette logique vers un client web moderne (TypeScript).
+3. Migrer le serveur vers Node.js de manière incrémentale.
+
+## Pourquoi pas “full haxe” ou “full node” ?
+
+### Full haxe
+**Avantages**
+- Proximité conceptuelle avec AS2/AS3.
+- Possibilité de partager du code logique entre cibles.
+
+**Inconvénients**
+- Écosystème web plus restreint que TypeScript.
+- Recrutement / maintenance potentiellement plus difficiles à long terme.
+
+### Full node.js + TypeScript
+**Avantages**
+- Écosystème moderne massif.
+- Outils de test, CI/CD, observabilité très matures.
+- Plus simple pour trouver des contributeurs.
+
+**Inconvénients**
+- Réécriture plus importante si vous faites un “big bang”.
+
+## Stratégie recommandée (sans big bang)
+
+### Phase 0 — Cartographie (1 à 2 semaines)
+- Inventorier les modules critiques (`frutiengine`, `frutiparc`, loaders, auth, chat, mini-jeux, UI).
+- Lister dépendances externes (URLs, protocoles, formats de données).
+- Capturer le comportement actuel (vidéos, captures, scripts de test).
+
+### Phase 1 — Compatibilité protocole (2 à 4 semaines)
+- Définir un contrat d’API moderne (REST/WS) qui encapsule l’ancien protocole.
+- Créer un **BFF Node.js** (Backend for Frontend) qui parle à l’ancien système.
+- Ajouter logs structurés pour comprendre trafic réel.
+
+### Phase 2 — Client web moderne (4 à 10 semaines)
+- Construire shell app (routing, auth, state management).
+- Refaire l’UI principale en web.
+- Porter les composants interactifs Flash vers Canvas/WebGL (PixiJS).
+
+### Phase 3 — Portage logique métier (continu)
+- Priorité: code à forte valeur + fort risque (sessions, permissions, inventaires, salon/chat, mini-jeux populaires).
+- Option A: portage direct en TypeScript.
+- Option B: portage intermédiaire en Haxe -> JS pour réduire les régressions.
+
+### Phase 4 — Retrait progressif Flash
+- Feature flags entre ancien et nouveau client.
+- Migration par cohortes d’utilisateurs.
+- Décommission finale quand parité atteinte.
+
+## Architecture cible minimale
+
+- `apps/web`: client TypeScript (React/Vue/Svelte selon préférence).
+- `apps/api`: Node.js (NestJS/Fastify) + WebSocket.
+- `packages/core`: logique métier partagée.
+- `packages/protocol`: schémas (zod/openapi/protobuf).
+- `infra/`: Docker, CI/CD, monitoring.
+
+## Risques principaux à traiter tôt
+
+- Comportements implicites de Flash (timing frame, depth, events).
+- Formats de données historiques non documentés.
+- Sécurité (auth legacy, XSS/CSRF, sessions).
+- Régressions gameplay sur mini-jeux.
+
+## Prochaine action concrète
+
+1. Choisir un **vertical slice**: login + hub + 1 mini-jeu.
+2. Le porter en stack moderne complète.
+3. Mesurer: temps de chargement, stabilité, retours utilisateurs.
+4. Répliquer pattern module par module.
+
+## Verdict techno (pragmatique)
+
+Si votre priorité est la maintenabilité long terme: **Node.js + TypeScript** comme base.
+
+Si votre priorité est de préserver rapidement la logique AS2 existante avec moins de casse: **Haxe comme étape de transition**, puis convergence vers TypeScript au fil du temps.
+
+## Mise en route réalisée
+
+- Un guide d’exécution pas à pas est disponible dans `docs/STEP_BY_STEP_HAXE_TO_TS.md`.
+- Un inventaire automatisé AS2 est fourni via `tools/migration/inventory_as2.js` (sortie: `migration/inventory/as2-inventory.json`).

--- a/docs/COMMENT_TESTER.md
+++ b/docs/COMMENT_TESTER.md
@@ -1,0 +1,63 @@
+# Comment tester (débutant)
+
+Ce guide est fait pour lancer le **premier MVP** sans connaissances techniques avancées.
+
+## 1) Prérequis
+
+Vérifie que Node.js est installé:
+
+```bash
+node -v
+```
+
+Tu dois voir une version (ex: `v22.x.x`).
+
+## 2) Ouvrir le projet
+
+Dans un terminal, place-toi dans le dossier du projet:
+
+```bash
+cd /workspace/Frutiparc
+```
+
+## 3) Lancer le MVP (commande unique)
+
+```bash
+bash tools/migration/run_mvp.sh
+```
+
+Cette commande fait automatiquement:
+1. l’inventaire des fichiers ActionScript,
+2. la sélection des 5 premiers modules “Lot A” (les plus simples pour commencer Haxe).
+
+## 4) Lire les résultats
+
+- Rapport humain (facile à lire): `docs/MVP_LOT_A.md`
+- Résultat machine (JSON): `migration/inventory/lot-a-candidates.json`
+
+## 5) Vérifier que ça a marché
+
+Tu dois voir à la fin du terminal:
+
+- `✅ MVP prêt à vérifier.`
+- le chemin vers les deux fichiers ci-dessus.
+
+## Dépannage rapide
+
+### Erreur: `node: command not found`
+Node.js n’est pas installé (ou pas dans le PATH).
+
+### Erreur: `Missing inventory file`
+Relance simplement la commande unique:
+
+```bash
+bash tools/migration/run_mvp.sh
+```
+
+### Erreur de permissions sur le script
+Lancer:
+
+```bash
+chmod +x tools/migration/run_mvp.sh
+bash tools/migration/run_mvp.sh
+```

--- a/docs/MVP_LOT_A.md
+++ b/docs/MVP_LOT_A.md
@@ -1,0 +1,22 @@
+# MVP Lot A — Modules candidats (Haxe first)
+
+Généré le: 2026-03-29T16:16:17.693Z
+
+Ces 5 modules sont les meilleurs candidats initiaux pour le portage Haxe (faible dépendance runtime Flash).
+
+| Module | Score | Lignes | Classes | XML | Notes |
+|---|---:|---:|---|---|---|
+| `frutiengine/Window.as` | 14 | 13 | Window | Non | has class declaration |
+| `frutiengine/FECMItem.as` | 14 | 18 | FECMItem | Non | has class declaration |
+| `frutiengine/FEColor.as` | 14 | 19 | FEColor | Non | has class declaration |
+| `frutiengine/Desktop.as` | 14 | 20 | Desktop | Non | has class declaration |
+| `frutiengine/CBeeLC.as` | 14 | 21 | CBeeLC | Non | has class declaration |
+
+## Test rapide
+
+```bash
+node tools/migration/inventory_as2.js
+node tools/migration/select_lot_a.js
+```
+
+Si ces modules vous conviennent, on peut démarrer le portage Haxe du premier module dès l’étape suivante.

--- a/docs/STEP_BY_STEP_HAXE_TO_TS.md
+++ b/docs/STEP_BY_STEP_HAXE_TO_TS.md
@@ -1,0 +1,78 @@
+# Migration Frutiparc: approche 2 (Haxe -> convergence TypeScript)
+
+Ce document lance l’approche que vous avez validée: **porter d’abord la logique en Haxe**, puis converger progressivement vers un socle **TypeScript/Node.js**.
+
+## Étape 1 (maintenant) — Inventaire automatique du code AS2
+
+### Objectif
+Obtenir une cartographie exploitable des sources ActionScript (fichiers, classes, dépendances et APIs Flash sensibles).
+
+### Commande
+```bash
+node tools/migration/inventory_as2.js
+```
+
+### Résultat
+- Génère `migration/inventory/as2-inventory.json`.
+- Ce JSON servira de base pour prioriser le portage Haxe module par module.
+
+## Étape 2 — Définir les lots de portage Haxe
+
+À partir de l’inventaire:
+1. Classer les modules par criticité (auth, session, chat, inventaire, mini-jeux).
+2. Identifier ceux qui dépendent le plus du runtime Flash (`attachMovie`, `loadMovie`, `onClipEvent`) pour les traiter à part.
+3. Créer 3 lots:
+   - **Lot A (métier pur)**: portable rapidement en Haxe.
+   - **Lot B (métier + I/O)**: nécessite adaptateurs.
+   - **Lot C (UI/Flash direct)**: à réécrire côté client TypeScript/PixiJS.
+
+## Étape 3 — Créer le noyau Haxe
+
+Créer un module `packages/core-haxe` avec:
+- modèles de domaine (User, Room, Item, etc.),
+- services métier purs,
+- tests unitaires de non-régression.
+
+Cible recommandée au départ: **JavaScript** (pour intégration rapide au futur client/server TS).
+
+## Étape 4 — Brancher le noyau Haxe dans une app Node.js
+
+- Exposer les fonctions Haxe compilées JS dans `apps/api`.
+- Ajouter une couche anti-corruption qui convertit les anciens formats Frutiparc vers des DTO modernes.
+- Couvrir par des tests de contrat (entrées/sorties attendues).
+
+## Étape 5 — Convergence TypeScript progressive
+
+Pour chaque module Haxe stabilisé:
+1. Réécrire en TypeScript avec tests équivalents.
+2. Exécuter les deux implémentations en parallèle derrière un feature flag.
+3. Retirer la version Haxe après validation métriques + QA.
+
+## Définition de “Done” par module
+
+- Parité fonctionnelle validée.
+- Tests unitaires + contrat verts.
+- Aucun appel direct au runtime Flash dans le module.
+- Observabilité en place (logs + métriques d’erreur).
+
+## Prochaine exécution immédiate
+
+1. Lancer `node tools/migration/inventory_as2.js`.
+2. Ouvrir `migration/inventory/as2-inventory.json`.
+3. Choisir ensemble le **Lot A** (3 à 5 modules) pour commencer le portage Haxe.
+
+## Étape 2bis (outillage prêt) — Sélection automatique du Lot A
+
+Commande:
+```bash
+node tools/migration/select_lot_a.js
+```
+
+Sorties:
+- `migration/inventory/lot-a-candidates.json`
+- `docs/MVP_LOT_A.md`
+
+## Pour tester facilement (débutant)
+
+- Guide simple: `docs/COMMENT_TESTER.md`
+- Commande unique: `bash tools/migration/run_mvp.sh`

--- a/migration/inventory/as2-inventory.json
+++ b/migration/inventory/as2-inventory.json
@@ -1,0 +1,1062 @@
+{
+  "summary": {
+    "generatedAt": "2026-03-29T16:16:17.620Z",
+    "fileCount": 81,
+    "totalLines": 14102,
+    "filesWithOnClipEvent": 0,
+    "filesWithAttachMovie": 9,
+    "filesWithLoadMovie": 2,
+    "filesWithXml": 11
+  },
+  "files": [
+    {
+      "file": "frutiengine/Array.class.as",
+      "lines": 255,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/CBee.as",
+      "lines": 296,
+      "classes": [
+        "CBee"
+      ],
+      "extends": [
+        "XMLSocket"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": true
+    },
+    {
+      "file": "frutiengine/CBeeLC.as",
+      "lines": 21,
+      "classes": [
+        "CBeeLC"
+      ],
+      "extends": [
+        "LocalConnection"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/CBeeManager.as",
+      "lines": 188,
+      "classes": [
+        "CBeeManager"
+      ],
+      "extends": [
+        "LocalConnection"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": true
+    },
+    {
+      "file": "frutiengine/Desktop.as",
+      "lines": 20,
+      "classes": [
+        "Desktop"
+      ],
+      "extends": [
+        "Slot"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/FECMItem.as",
+      "lines": 18,
+      "classes": [
+        "FECMItem"
+      ],
+      "extends": [
+        "ContextMenuItem"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/FEColor.as",
+      "lines": 19,
+      "classes": [
+        "FEColor"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/FEDate.as",
+      "lines": 138,
+      "classes": [
+        "FEDate"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/FEMC.as",
+      "lines": 386,
+      "classes": [
+        "FEMC"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": true,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/FEMCLoader.as",
+      "lines": 51,
+      "classes": [
+        "FEMCLoader"
+      ],
+      "extends": [
+        "MovieClipLoader"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/FENumber.as",
+      "lines": 117,
+      "classes": [
+        "FENumber"
+      ],
+      "extends": [
+        "ext.util.MTNumber"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/FEObject.as",
+      "lines": 44,
+      "classes": [
+        "FEObject"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/FEString.as",
+      "lines": 491,
+      "classes": [
+        "FEString"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": true
+    },
+    {
+      "file": "frutiengine/FFileMng.as",
+      "lines": 113,
+      "classes": [
+        "FFileMng"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/FileLoader.as",
+      "lines": 165,
+      "classes": [
+        "FileLoader"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/frusion_content/CBeeLocal.as",
+      "lines": 77,
+      "classes": [
+        "CBeeLocal"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/frusion_external/CBeeLocal.as",
+      "lines": 194,
+      "classes": [
+        "CBeeLocal"
+      ],
+      "extends": [
+        "LocalConnection"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": true
+    },
+    {
+      "file": "frutiengine/frusion_internal/CBeeLocal.as",
+      "lines": 183,
+      "classes": [
+        "CBeeLocal"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": true
+    },
+    {
+      "file": "frutiengine/HTTP.as",
+      "lines": 159,
+      "classes": [
+        "HTTP"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": true
+    },
+    {
+      "file": "frutiengine/Lang.as",
+      "lines": 168,
+      "classes": [
+        "Lang"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/MD5.as",
+      "lines": 185,
+      "classes": [
+        "MD5"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/MovieClip.class.as",
+      "lines": 346,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": true,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/Pref.as",
+      "lines": 177,
+      "classes": [
+        "Pref"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/RunDate.as",
+      "lines": 75,
+      "classes": [
+        "RunDate"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/Slot.as",
+      "lines": 184,
+      "classes": [
+        "Slot"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/SlotList.as",
+      "lines": 85,
+      "classes": [
+        "SlotList"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/StatusMng.as",
+      "lines": 79,
+      "classes": [
+        "StatusMng"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/Tab.as",
+      "lines": 31,
+      "classes": [
+        "Tab"
+      ],
+      "extends": [
+        "Slot"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/TextField.class.as",
+      "lines": 46,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/UserListMng.as",
+      "lines": 207,
+      "classes": [
+        "UserListMng"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/UserMng.as",
+      "lines": 214,
+      "classes": [
+        "UserMng"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/WinBox.as",
+      "lines": 101,
+      "classes": [
+        "WinBox"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/Window.as",
+      "lines": 13,
+      "classes": [
+        "Window"
+      ],
+      "extends": [
+        "MovieClip"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/WinStandard.as",
+      "lines": 732,
+      "classes": [
+        "WinStandard"
+      ],
+      "extends": [
+        "Window"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": true,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/BlackList.as",
+      "lines": 60,
+      "classes": [
+        "BlackList"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/cmdList.as",
+      "lines": 8,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/cmdList2.as",
+      "lines": 85,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/ContactList.as",
+      "lines": 73,
+      "classes": [
+        "ContactList"
+      ],
+      "extends": [
+        "IconFileBox"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/ContactListCache.as",
+      "lines": 51,
+      "classes": [
+        "ContactListCache"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/Depths.as",
+      "lines": 43,
+      "classes": [
+        "Depths"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/first.as",
+      "lines": 32,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": true,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/FPCBee.as",
+      "lines": 587,
+      "classes": [
+        "FPCBee"
+      ],
+      "extends": [
+        "CBee"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": true
+    },
+    {
+      "file": "frutiparc/FPCBeeManager.as",
+      "lines": 21,
+      "classes": [
+        "FPCBeeManager"
+      ],
+      "extends": [
+        "CBeeManager"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/FPDesktop.as",
+      "lines": 330,
+      "classes": [
+        "FPDesktop"
+      ],
+      "extends": [
+        "Desktop"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": true,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/FPFileMng.as",
+      "lines": 536,
+      "classes": [
+        "FPFileMng"
+      ],
+      "extends": [
+        "FFileMng"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/FPForumSlot.as",
+      "lines": 94,
+      "classes": [
+        "FPForumSlot"
+      ],
+      "extends": [
+        "Slot"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": true,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/FPPlugin.class.as",
+      "lines": 207,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/FPSlotList.as",
+      "lines": 91,
+      "classes": [
+        "FPSlotList"
+      ],
+      "extends": [
+        "SlotList"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/FPString.as",
+      "lines": 37,
+      "classes": [
+        "FPString"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/FPTab.as",
+      "lines": 92,
+      "classes": [
+        "FPTab"
+      ],
+      "extends": [
+        "Tab"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/FPTopDesktop.as",
+      "lines": 57,
+      "classes": [
+        "FPTopDesktop"
+      ],
+      "extends": [
+        "FPDesktop"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/FPTrashSlot.as",
+      "lines": 16,
+      "classes": [
+        "FPTrashSlot"
+      ],
+      "extends": [
+        "Slot"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/FrutizInfo.as",
+      "lines": 516,
+      "classes": [
+        "FrutizInfo"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": true
+    },
+    {
+      "file": "frutiparc/global.as",
+      "lines": 299,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/IconFileBox.as",
+      "lines": 193,
+      "classes": [
+        "IconFileBox"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/init_final.as",
+      "lines": 26,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/init.as",
+      "lines": 264,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": true,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/InviteMng.as",
+      "lines": 54,
+      "classes": [
+        "InviteMng"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/lang_french.as",
+      "lines": 899,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": true
+    },
+    {
+      "file": "frutiparc/lib/box/init.as",
+      "lines": 41,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/lib/fe/init.as",
+      "lines": 40,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/lib/frusion/init.as",
+      "lines": 18,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/lib/interface/init.as",
+      "lines": 155,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/lib/listener/init.as",
+      "lines": 16,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/lib/root/init.as",
+      "lines": 28,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/lib/unsorted/init.as",
+      "lines": 78,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/listener/dragIconMouse.as",
+      "lines": 50,
+      "classes": [
+        "listener"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/listener/key.as",
+      "lines": 16,
+      "classes": [
+        "listener"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/listener/main.as",
+      "lines": 1225,
+      "classes": [
+        "listener"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/listener/mouse.as",
+      "lines": 12,
+      "classes": [
+        "listener"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/loading.as",
+      "lines": 103,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": true,
+      "hasLoadMovie": true,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/main/classLoader.as",
+      "lines": 60,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/MeMng.as",
+      "lines": 264,
+      "classes": [
+        "MeMng"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/openFunctions.as",
+      "lines": 660,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": true,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/Path.as",
+      "lines": 68,
+      "classes": [
+        "Path"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/registerSymphony.as",
+      "lines": 138,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/Standard.as",
+      "lines": 569,
+      "classes": [
+        "Standard"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": true
+    },
+    {
+      "file": "frutiparc/test_game/CBeeLocal.as",
+      "lines": 72,
+      "classes": [
+        "CBeeLocal"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/test_game/init.as",
+      "lines": 28,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/TipTextMng.as",
+      "lines": 84,
+      "classes": [
+        "TipTextMng"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": true,
+      "hasLoadMovie": false,
+      "hasXml": true
+    },
+    {
+      "file": "frutiparc/WallPaperMng.as",
+      "lines": 128,
+      "classes": [
+        "WallPaperMng"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    }
+  ]
+}

--- a/migration/inventory/lot-a-candidates.json
+++ b/migration/inventory/lot-a-candidates.json
@@ -1,0 +1,85 @@
+{
+  "generatedAt": "2026-03-29T16:16:17.693Z",
+  "strategy": "Haxe-first migration: select low-Flash-dependency business logic modules",
+  "sourceInventory": "migration/inventory/as2-inventory.json",
+  "candidates": [
+    {
+      "file": "frutiengine/Window.as",
+      "score": 14,
+      "lines": 13,
+      "classes": [
+        "Window"
+      ],
+      "extends": [
+        "MovieClip"
+      ],
+      "importsCount": 0,
+      "hasXml": false,
+      "reasons": [
+        "has class declaration"
+      ]
+    },
+    {
+      "file": "frutiengine/FECMItem.as",
+      "score": 14,
+      "lines": 18,
+      "classes": [
+        "FECMItem"
+      ],
+      "extends": [
+        "ContextMenuItem"
+      ],
+      "importsCount": 0,
+      "hasXml": false,
+      "reasons": [
+        "has class declaration"
+      ]
+    },
+    {
+      "file": "frutiengine/FEColor.as",
+      "score": 14,
+      "lines": 19,
+      "classes": [
+        "FEColor"
+      ],
+      "extends": [],
+      "importsCount": 0,
+      "hasXml": false,
+      "reasons": [
+        "has class declaration"
+      ]
+    },
+    {
+      "file": "frutiengine/Desktop.as",
+      "score": 14,
+      "lines": 20,
+      "classes": [
+        "Desktop"
+      ],
+      "extends": [
+        "Slot"
+      ],
+      "importsCount": 0,
+      "hasXml": false,
+      "reasons": [
+        "has class declaration"
+      ]
+    },
+    {
+      "file": "frutiengine/CBeeLC.as",
+      "score": 14,
+      "lines": 21,
+      "classes": [
+        "CBeeLC"
+      ],
+      "extends": [
+        "LocalConnection"
+      ],
+      "importsCount": 0,
+      "hasXml": false,
+      "reasons": [
+        "has class declaration"
+      ]
+    }
+  ]
+}

--- a/tools/migration/inventory_as2.js
+++ b/tools/migration/inventory_as2.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = process.cwd();
+const TARGET_DIRS = ['frutiengine', 'frutiparc'];
+const OUTPUT_FILE = path.join(ROOT, 'migration', 'inventory', 'as2-inventory.json');
+
+function walk(dir, collector) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(fullPath, collector);
+      continue;
+    }
+    if (entry.isFile() && fullPath.endsWith('.as')) {
+      collector.push(fullPath);
+    }
+  }
+}
+
+function parseFile(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const lines = content.split(/\r?\n/);
+
+  const classes = [...content.matchAll(/\bclass\s+([A-Za-z_][A-Za-z0-9_]*)/g)].map((m) => m[1]);
+  const extendsMatch = [...content.matchAll(/\bclass\s+[A-Za-z_][A-Za-z0-9_]*\s+extends\s+([A-Za-z_][A-Za-z0-9_.]*)/g)].map((m) => m[1]);
+  const imports = [...content.matchAll(/\bimport\s+([A-Za-z_][A-Za-z0-9_.]*)\s*;/g)].map((m) => m[1]);
+
+  return {
+    file: path.relative(ROOT, filePath),
+    lines: lines.length,
+    classes,
+    extends: extendsMatch,
+    imports,
+    hasOnClipEvent: /\bonClipEvent\b/.test(content),
+    hasAttachMovie: /\battachMovie\b/.test(content),
+    hasLoadMovie: /\bloadMovie\b/.test(content),
+    hasXml: /\bXML\b/.test(content),
+  };
+}
+
+function main() {
+  const files = [];
+  for (const dir of TARGET_DIRS) {
+    const full = path.join(ROOT, dir);
+    if (fs.existsSync(full)) {
+      walk(full, files);
+    }
+  }
+
+  const parsed = files
+    .map(parseFile)
+    .sort((a, b) => a.file.localeCompare(b.file, 'en'));
+
+  const summary = {
+    generatedAt: new Date().toISOString(),
+    fileCount: parsed.length,
+    totalLines: parsed.reduce((sum, f) => sum + f.lines, 0),
+    filesWithOnClipEvent: parsed.filter((f) => f.hasOnClipEvent).length,
+    filesWithAttachMovie: parsed.filter((f) => f.hasAttachMovie).length,
+    filesWithLoadMovie: parsed.filter((f) => f.hasLoadMovie).length,
+    filesWithXml: parsed.filter((f) => f.hasXml).length,
+  };
+
+  fs.mkdirSync(path.dirname(OUTPUT_FILE), { recursive: true });
+  fs.writeFileSync(
+    OUTPUT_FILE,
+    JSON.stringify({ summary, files: parsed }, null, 2) + '\n',
+    'utf8'
+  );
+
+  console.log(`AS2 inventory written to ${path.relative(ROOT, OUTPUT_FILE)}`);
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+main();

--- a/tools/migration/run_mvp.sh
+++ b/tools/migration/run_mvp.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "[1/2] Génération inventaire AS2..."
+node tools/migration/inventory_as2.js
+
+echo "[2/2] Sélection automatique du Lot A..."
+node tools/migration/select_lot_a.js
+
+echo ""
+echo "✅ MVP prêt à vérifier."
+echo "- Rapport lisible: docs/MVP_LOT_A.md"
+echo "- Données JSON : migration/inventory/lot-a-candidates.json"

--- a/tools/migration/select_lot_a.js
+++ b/tools/migration/select_lot_a.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = process.cwd();
+const INVENTORY_PATH = path.join(ROOT, 'migration', 'inventory', 'as2-inventory.json');
+const OUTPUT_JSON = path.join(ROOT, 'migration', 'inventory', 'lot-a-candidates.json');
+const OUTPUT_MD = path.join(ROOT, 'docs', 'MVP_LOT_A.md');
+
+function scoreFile(file) {
+  const penalty =
+    (file.hasAttachMovie ? 6 : 0) +
+    (file.hasLoadMovie ? 6 : 0) +
+    (file.hasOnClipEvent ? 6 : 0) +
+    (file.hasXml ? 2 : 0);
+
+  const classBonus = file.classes.length > 0 ? 2 : -2;
+  const sizePenalty = file.lines > 500 ? 4 : file.lines > 250 ? 2 : 0;
+  const engineBonus = file.file.startsWith('frutiengine/') ? 2 : 0;
+  const testPenalty = file.file.includes('test_game') ? 4 : 0;
+
+  const score = 10 + classBonus + engineBonus - penalty - sizePenalty - testPenalty;
+
+  return {
+    ...file,
+    score,
+    reasons: [
+      file.hasAttachMovie ? 'uses attachMovie' : null,
+      file.hasLoadMovie ? 'uses loadMovie' : null,
+      file.hasOnClipEvent ? 'uses onClipEvent' : null,
+      file.hasXml ? 'uses XML APIs' : null,
+      file.lines > 500 ? 'large file (>500 lines)' : null,
+      file.file.includes('test_game') ? 'test_game scope' : null,
+      file.classes.length === 0 ? 'no class declaration' : 'has class declaration',
+    ].filter(Boolean),
+  };
+}
+
+function main() {
+  if (!fs.existsSync(INVENTORY_PATH)) {
+    throw new Error(`Missing inventory file: ${path.relative(ROOT, INVENTORY_PATH)}. Run inventory_as2.js first.`);
+  }
+
+  const inventory = JSON.parse(fs.readFileSync(INVENTORY_PATH, 'utf8'));
+  const scored = inventory.files.map(scoreFile);
+
+  const candidates = scored
+    .filter((f) => !f.hasAttachMovie && !f.hasLoadMovie && !f.hasOnClipEvent)
+    .filter((f) => !f.file.includes('test_game'))
+    .sort((a, b) => b.score - a.score || a.lines - b.lines)
+    .slice(0, 5)
+    .map((f) => ({
+      file: f.file,
+      score: f.score,
+      lines: f.lines,
+      classes: f.classes,
+      extends: f.extends,
+      importsCount: f.imports.length,
+      hasXml: f.hasXml,
+      reasons: f.reasons,
+    }));
+
+  const payload = {
+    generatedAt: new Date().toISOString(),
+    strategy: 'Haxe-first migration: select low-Flash-dependency business logic modules',
+    sourceInventory: path.relative(ROOT, INVENTORY_PATH),
+    candidates,
+  };
+
+  fs.mkdirSync(path.dirname(OUTPUT_JSON), { recursive: true });
+  fs.writeFileSync(OUTPUT_JSON, JSON.stringify(payload, null, 2) + '\n', 'utf8');
+
+  const lines = [
+    '# MVP Lot A — Modules candidats (Haxe first)',
+    '',
+    `Généré le: ${payload.generatedAt}`,
+    '',
+    'Ces 5 modules sont les meilleurs candidats initiaux pour le portage Haxe (faible dépendance runtime Flash).',
+    '',
+    '| Module | Score | Lignes | Classes | XML | Notes |',
+    '|---|---:|---:|---|---|---|',
+    ...candidates.map((c) =>
+      `| \`${c.file}\` | ${c.score} | ${c.lines} | ${c.classes.join(', ') || '-'} | ${c.hasXml ? 'Oui' : 'Non'} | ${c.reasons.join('; ')} |`
+    ),
+    '',
+    '## Test rapide',
+    '',
+    '```bash',
+    'node tools/migration/inventory_as2.js',
+    'node tools/migration/select_lot_a.js',
+    '```',
+    '',
+    'Si ces modules vous conviennent, on peut démarrer le portage Haxe du premier module dès l’étape suivante.',
+  ];
+
+  fs.writeFileSync(OUTPUT_MD, lines.join('\n') + '\n', 'utf8');
+
+  console.log(`Lot A candidates written to ${path.relative(ROOT, OUTPUT_JSON)}`);
+  console.log(`MVP report written to ${path.relative(ROOT, OUTPUT_MD)}`);
+}
+
+main();


### PR DESCRIPTION
### Motivation

- Provide a clear migration strategy and on-ramp for modernizing legacy ActionScript 2 / Flash code into Haxe/TypeScript-based stacks.
- Automate discovery of AS2 sources to prioritize low-runtime-dependency modules for an initial Haxe port (Lot A).
- Ship a simple, beginner-friendly workflow to run the inventory and generate a human-readable MVP report.

### Description

- Add a high-level migration plan `MIGRATION_PLAN.md` and step-by-step guides `STEP_BY_STEP_HAXE_TO_TS.md` and `docs/COMMENT_TESTER.md` to document the recommended approach.
- Add inventory tooling `tools/migration/inventory_as2.js` to scan `.as` files and produce `migration/inventory/as2-inventory.json` with file metadata and runtime-API usage flags.
- Add a scoring/selection script `tools/migration/select_lot_a.js` that picks the top 5 low-Flash-dependency candidates and writes `migration/inventory/lot-a-candidates.json` and `docs/MVP_LOT_A.md` (Markdown report).
- Add a small runner `tools/migration/run_mvp.sh` (executable) that runs the inventory and selection steps and prints output locations.

### Testing

- Executed the inventory generation with `node tools/migration/inventory_as2.js` which completed successfully and produced `migration/inventory/as2-inventory.json` as shown in the repository.
- Executed the Lot A selector with `node tools/migration/select_lot_a.js` which completed successfully and produced `migration/inventory/lot-a-candidates.json` and `docs/MVP_LOT_A.md` as shown in the repository.
- Ran the end-to-end helper `bash tools/migration/run_mvp.sh` which ran both steps and exited without errors, printing the reported artifact paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c94b569c9c832096167350726250a7)