### PR TITLE
Add migration plan, Haxe core ports, JS runtime mirrors, tooling and comprehensive migration tests

### DIFF
--- a/MIGRATION_PLAN.md
+++ b/MIGRATION_PLAN.md
@@ -1,0 +1,94 @@
+# Plan de modernisation de Frutiparc (Flash 2003-2004)
+
+Ce dépôt contient un code ActionScript 2 / Flash historique. Le plus sûr est une **migration progressive**, avec un objectif de compatibilité fonctionnelle avant toute refonte UX.
+
+## Recommandation courte
+
+- **Front-end**: TypeScript + moteur 2D web (PixiJS) pour remplacer l’affichage Flash.
+- **Back-end**: Node.js (NestJS ou Fastify) pour services, sessions, API.
+- **Option haxe**: utile si vous voulez conserver une logique proche d’AS2 et cibler JS avec moins de réécriture initiale.
+
+👉 En pratique, un bon compromis est:
+1. Convertir/porter la logique métier la plus sensible en **Haxe** (si le code AS2 est dense et fragile).
+2. Exposer cette logique vers un client web moderne (TypeScript).
+3. Migrer le serveur vers Node.js de manière incrémentale.
+
+## Pourquoi pas “full haxe” ou “full node” ?
+
+### Full haxe
+**Avantages**
+- Proximité conceptuelle avec AS2/AS3.
+- Possibilité de partager du code logique entre cibles.
+
+**Inconvénients**
+- Écosystème web plus restreint que TypeScript.
+- Recrutement / maintenance potentiellement plus difficiles à long terme.
+
+### Full node.js + TypeScript
+**Avantages**
+- Écosystème moderne massif.
+- Outils de test, CI/CD, observabilité très matures.
+- Plus simple pour trouver des contributeurs.
+
+**Inconvénients**
+- Réécriture plus importante si vous faites un “big bang”.
+
+## Stratégie recommandée (sans big bang)
+
+### Phase 0 — Cartographie (1 à 2 semaines)
+- Inventorier les modules critiques (`frutiengine`, `frutiparc`, loaders, auth, chat, mini-jeux, UI).
+- Lister dépendances externes (URLs, protocoles, formats de données).
+- Capturer le comportement actuel (vidéos, captures, scripts de test).
+
+### Phase 1 — Compatibilité protocole (2 à 4 semaines)
+- Définir un contrat d’API moderne (REST/WS) qui encapsule l’ancien protocole.
+- Créer un **BFF Node.js** (Backend for Frontend) qui parle à l’ancien système.
+- Ajouter logs structurés pour comprendre trafic réel.
+
+### Phase 2 — Client web moderne (4 à 10 semaines)
+- Construire shell app (routing, auth, state management).
+- Refaire l’UI principale en web.
+- Porter les composants interactifs Flash vers Canvas/WebGL (PixiJS).
+
+### Phase 3 — Portage logique métier (continu)
+- Priorité: code à forte valeur + fort risque (sessions, permissions, inventaires, salon/chat, mini-jeux populaires).
+- Option A: portage direct en TypeScript.
+- Option B: portage intermédiaire en Haxe -> JS pour réduire les régressions.
+
+### Phase 4 — Retrait progressif Flash
+- Feature flags entre ancien et nouveau client.
+- Migration par cohortes d’utilisateurs.
+- Décommission finale quand parité atteinte.
+
+## Architecture cible minimale
+
+- `apps/web`: client TypeScript (React/Vue/Svelte selon préférence).
+- `apps/api`: Node.js (NestJS/Fastify) + WebSocket.
+- `packages/core`: logique métier partagée.
+- `packages/protocol`: schémas (zod/openapi/protobuf).
+- `infra/`: Docker, CI/CD, monitoring.
+
+## Risques principaux à traiter tôt
+
+- Comportements implicites de Flash (timing frame, depth, events).
+- Formats de données historiques non documentés.
+- Sécurité (auth legacy, XSS/CSRF, sessions).
+- Régressions gameplay sur mini-jeux.
+
+## Prochaine action concrète
+
+1. Choisir un **vertical slice**: login + hub + 1 mini-jeu.
+2. Le porter en stack moderne complète.
+3. Mesurer: temps de chargement, stabilité, retours utilisateurs.
+4. Répliquer pattern module par module.
+
+## Verdict techno (pragmatique)
+
+Si votre priorité est la maintenabilité long terme: **Node.js + TypeScript** comme base.
+
+Si votre priorité est de préserver rapidement la logique AS2 existante avec moins de casse: **Haxe comme étape de transition**, puis convergence vers TypeScript au fil du temps.
+
+## Mise en route réalisée
+
+- Un guide d’exécution pas à pas est disponible dans `docs/STEP_BY_STEP_HAXE_TO_TS.md`.
+- Un inventaire automatisé AS2 est fourni via `tools/migration/inventory_as2.js` (sortie: `migration/inventory/as2-inventory.json`).

--- a/README.md
+++ b/README.md
@@ -24,3 +24,15 @@ server running on `localhost:8888`.
 
 If everything is accessible, the progress bar shown by `main.swf` will
 continue past 10 % and the game will start.
+
+
+## Tester la version portée (sans Ruffle / sans `main.swf`)
+
+Tu peux tester la version Node des modules portés via l'endpoint MVP:
+
+```bash
+curl http://localhost:8888/api/mvp/showcase
+```
+
+Cet endpoint exécute les modules portés (`feString`, `feColor`, `statusMng`, `classLoader`)
+et renvoie un JSON de démonstration.

--- a/docs/COMMENT_TESTER.md
+++ b/docs/COMMENT_TESTER.md
@@ -1,0 +1,63 @@
+# Comment tester (débutant)
+
+Ce guide est fait pour lancer le **premier MVP** sans connaissances techniques avancées.
+
+## 1) Prérequis
+
+Vérifie que Node.js est installé:
+
+```bash
+node -v
+```
+
+Tu dois voir une version (ex: `v22.x.x`).
+
+## 2) Ouvrir le projet
+
+Dans un terminal, place-toi dans le dossier du projet:
+
+```bash
+cd /workspace/Frutiparc
+```
+
+## 3) Lancer le MVP (commande unique)
+
+```bash
+bash tools/migration/run_mvp.sh
+```
+
+Cette commande fait automatiquement:
+1. l’inventaire des fichiers ActionScript,
+2. la sélection des 5 premiers modules “Lot A” (les plus simples pour commencer Haxe).
+
+## 4) Lire les résultats
+
+- Rapport humain (facile à lire): `docs/MVP_LOT_A.md`
+- Résultat machine (JSON): `migration/inventory/lot-a-candidates.json`
+
+## 5) Vérifier que ça a marché
+
+Tu dois voir à la fin du terminal:
+
+- `✅ MVP prêt à vérifier.`
+- le chemin vers les deux fichiers ci-dessus.
+
+## Dépannage rapide
+
+### Erreur: `node: command not found`
+Node.js n’est pas installé (ou pas dans le PATH).
+
+### Erreur: `Missing inventory file`
+Relance simplement la commande unique:
+
+```bash
+bash tools/migration/run_mvp.sh
+```
+
+### Erreur de permissions sur le script
+Lancer:
+
+```bash
+chmod +x tools/migration/run_mvp.sh
+bash tools/migration/run_mvp.sh
+```

--- a/docs/LOT_A_PROGRESS.md
+++ b/docs/LOT_A_PROGRESS.md
@@ -1,0 +1,111 @@
+# Avancement Lot A (Haxe -> TypeScript)
+
+## État actuel
+
+- ✅ **Module FEColor** porté en Haxe: `packages/core-haxe/src/frutiparc/core/FEColor.hx`
+- ✅ **Module Window** porté en Haxe: `packages/core-haxe/src/frutiparc/core/Window.hx`
+- ✅ **Module FECMItem** porté en Haxe: `packages/core-haxe/src/frutiparc/core/FECMItem.hx`
+- ✅ **Module Desktop** porté en Haxe: `packages/core-haxe/src/frutiparc/core/Desktop.hx`
+- ✅ **Module CBeeLC** porté en Haxe: `packages/core-haxe/src/frutiparc/core/CBeeLC.hx`
+- ✅ **Module FEString** porté en Haxe (subset pragmatique + `formatVars`): `packages/core-haxe/src/frutiparc/core/FEString.hx`
+- ✅ **Module FENumber** porté en Haxe (subset utile): `packages/core-haxe/src/frutiparc/core/FENumber.hx`
+- ✅ **Module FEDate** porté en Haxe (subset utile): `packages/core-haxe/src/frutiparc/core/FEDate.hx`
+- ✅ **Module FEObject** porté en Haxe (subset utile): `packages/core-haxe/src/frutiparc/core/FEObject.hx`
+- ✅ **Module Pref** porté en Haxe (noyau métier): `packages/core-haxe/src/frutiparc/core/Pref.hx`
+- ✅ **Module RunDate** porté en Haxe (noyau métier): `packages/core-haxe/src/frutiparc/core/RunDate.hx`
+- ✅ **Module Lang** porté en Haxe (noyau formatage): `packages/core-haxe/src/frutiparc/core/Lang.hx`
+- ✅ **Module MD5** porté en Haxe: `packages/core-haxe/src/frutiparc/core/MD5.hx`
+- ✅ **Module HTTP** porté en Haxe (queue + callback orchestration): `packages/core-haxe/src/frutiparc/core/HTTP.hx`
+- ✅ **Module FileLoader** porté en Haxe (état + événements): `packages/core-haxe/src/frutiparc/core/FileLoader.hx`
+- ✅ **Module FEMCLoader** porté en Haxe (déduplication de chargements): `packages/core-haxe/src/frutiparc/core/FEMCLoader.hx`
+- ✅ **Module FFileMng** porté en Haxe (arbre et parsing XML): `packages/core-haxe/src/frutiparc/core/FFileMng.hx`
+- ✅ **Module UserMng** porté en Haxe (helpers XP/profil + état utilisateur): `packages/core-haxe/src/frutiparc/core/UserMng.hx`
+- ✅ **Module UserListMng** porté en Haxe (gestion liste utilisateurs + listeners paginés): `packages/core-haxe/src/frutiparc/core/UserListMng.hx`
+- ✅ **Module StatusMng** porté en Haxe (encodage/décodage statut + émission cnx): `packages/core-haxe/src/frutiparc/core/StatusMng.hx`
+- ✅ **Module SlotList** porté en Haxe (profondeur slots + activation): `packages/core-haxe/src/frutiparc/core/SlotList.hx`
+- ✅ **Module Slot** porté en Haxe (gestion box, activation et warning): `packages/core-haxe/src/frutiparc/core/Slot.hx`
+- ✅ **Module WinBox** porté en Haxe (cycle de vie fenêtre + slot hooks): `packages/core-haxe/src/frutiparc/core/WinBox.hx`
+- ✅ **Module WinStandard** porté en Haxe (subset logique: recal/resize/modes): `packages/core-haxe/src/frutiparc/core/WinStandard.hx`
+- ✅ **Module Tab** porté en Haxe (slot mono-box + auto-close): `packages/core-haxe/src/frutiparc/core/Tab.hx`
+- ✅ **Module FEMC** porté en Haxe (subset non-Flash: couleur/bouton/path): `packages/core-haxe/src/frutiparc/core/FEMC.hx`
+- ✅ **Module CBee** porté en Haxe (subset orchestration commandes/listeners): `packages/core-haxe/src/frutiparc/core/CBee.hx`
+- ✅ **Module CBeeManager** porté en Haxe (pool de connexions + listeners): `packages/core-haxe/src/frutiparc/core/CBeeManager.hx`
+- ✅ **Module CBeeLocal** porté en Haxe (bridge local + listeners commandes): `packages/core-haxe/src/frutiparc/core/CBeeLocal.hx`
+- ✅ **Module ClassLoader** porté en Haxe (chargement séquentiel des libs): `packages/core-haxe/src/frutiparc/core/ClassLoader.hx`
+- ✅ Base transitoire `Slot` introduite: `packages/core-haxe/src/frutiparc/core/SlotBase.hx`
+- ✅ Miroirs runtime JS ajoutés pour intégration immédiate Node:
+  - `packages/core-js/src/feColor.js`
+  - `packages/core-js/src/window.js`
+  - `packages/core-js/src/fecmItem.js`
+  - `packages/core-js/src/slotBase.js`
+  - `packages/core-js/src/desktop.js`
+  - `packages/core-js/src/cbeeLc.js`
+  - `packages/core-js/src/feString.js`
+  - `packages/core-js/src/feNumber.js`
+  - `packages/core-js/src/feDate.js`
+  - `packages/core-js/src/feObject.js`
+  - `packages/core-js/src/pref.js`
+  - `packages/core-js/src/runDate.js`
+  - `packages/core-js/src/lang.js`
+  - `packages/core-js/src/md5.js`
+  - `packages/core-js/src/http.js`
+  - `packages/core-js/src/fileLoader.js`
+  - `packages/core-js/src/femcLoader.js`
+  - `packages/core-js/src/fFileMng.js`
+  - `packages/core-js/src/userMng.js`
+  - `packages/core-js/src/userListMng.js`
+  - `packages/core-js/src/statusMng.js`
+  - `packages/core-js/src/slotList.js`
+  - `packages/core-js/src/slot.js`
+  - `packages/core-js/src/winBox.js`
+  - `packages/core-js/src/winStandard.js`
+  - `packages/core-js/src/tab.js`
+  - `packages/core-js/src/femc.js`
+  - `packages/core-js/src/cbee.js`
+  - `packages/core-js/src/cbeeManager.js`
+  - `packages/core-js/src/cbeeLocal.js`
+  - `packages/core-js/src/classLoader.js`
+- ✅ Tests de parité ajoutés:
+  - `tests/migration/feColor.spec.js`
+  - `tests/migration/window.spec.js`
+  - `tests/migration/fecmItem.spec.js`
+  - `tests/migration/desktop.spec.js`
+  - `tests/migration/cbeeLc.spec.js`
+  - `tests/migration/feString.spec.js`
+  - `tests/migration/feNumber.spec.js`
+  - `tests/migration/feDate.spec.js`
+  - `tests/migration/feObject.spec.js`
+  - `tests/migration/pref.spec.js`
+  - `tests/migration/runDate.spec.js`
+  - `tests/migration/lang.spec.js`
+  - `tests/migration/md5.spec.js`
+  - `tests/migration/http.spec.js`
+  - `tests/migration/fileLoader.spec.js`
+  - `tests/migration/femcLoader.spec.js`
+  - `tests/migration/fFileMng.spec.js`
+  - `tests/migration/userMng.spec.js`
+  - `tests/migration/userListMng.spec.js`
+  - `tests/migration/statusMng.spec.js`
+  - `tests/migration/slotList.spec.js`
+  - `tests/migration/slot.spec.js`
+  - `tests/migration/winBox.spec.js`
+  - `tests/migration/winStandard.spec.js`
+  - `tests/migration/tab.spec.js`
+  - `tests/migration/femc.spec.js`
+  - `tests/migration/cbee.spec.js`
+  - `tests/migration/cbeeManager.spec.js`
+  - `tests/migration/cbeeLocal.spec.js`
+  - `tests/migration/classLoader.spec.js`
+  - `tests/migration/mvpShowcase.spec.js`
+
+## Commandes de test
+
+```bash
+node --test tests/migration/feColor.spec.js tests/migration/window.spec.js tests/migration/fecmItem.spec.js tests/migration/desktop.spec.js tests/migration/cbeeLc.spec.js tests/migration/feString.spec.js tests/migration/feNumber.spec.js tests/migration/feDate.spec.js tests/migration/feObject.spec.js tests/migration/pref.spec.js tests/migration/runDate.spec.js tests/migration/lang.spec.js tests/migration/md5.spec.js tests/migration/http.spec.js tests/migration/fileLoader.spec.js tests/migration/femcLoader.spec.js tests/migration/fFileMng.spec.js tests/migration/userMng.spec.js tests/migration/userListMng.spec.js tests/migration/statusMng.spec.js tests/migration/slotList.spec.js tests/migration/slot.spec.js tests/migration/winBox.spec.js tests/migration/winStandard.spec.js tests/migration/tab.spec.js tests/migration/femc.spec.js tests/migration/cbee.spec.js tests/migration/cbeeManager.spec.js tests/migration/cbeeLocal.spec.js tests/migration/classLoader.spec.js tests/migration/mvpShowcase.spec.js
+```
+
+## Prochain module recommandé
+
+Étape CBeeLocal external/internal harmonisée (init/send/cmd/onStatus en miroir).
+
+Pour poursuivre, le prochain module conseillé est `frutiengine/frusion_internal/Manager.as` (orchestration globale de session/chargement proche de `main.swf`).

--- a/docs/MVP_LOT_A.md
+++ b/docs/MVP_LOT_A.md
@@ -1,0 +1,22 @@
+# MVP Lot A — Modules candidats (Haxe first)
+
+Généré le: 2026-03-29T16:16:17.693Z
+
+Ces 5 modules sont les meilleurs candidats initiaux pour le portage Haxe (faible dépendance runtime Flash).
+
+| Module | Score | Lignes | Classes | XML | Notes |
+|---|---:|---:|---|---|---|
+| `frutiengine/Window.as` | 14 | 13 | Window | Non | has class declaration |
+| `frutiengine/FECMItem.as` | 14 | 18 | FECMItem | Non | has class declaration |
+| `frutiengine/FEColor.as` | 14 | 19 | FEColor | Non | has class declaration |
+| `frutiengine/Desktop.as` | 14 | 20 | Desktop | Non | has class declaration |
+| `frutiengine/CBeeLC.as` | 14 | 21 | CBeeLC | Non | has class declaration |
+
+## Test rapide
+
+```bash
+node tools/migration/inventory_as2.js
+node tools/migration/select_lot_a.js
+```
+
+Si ces modules vous conviennent, on peut démarrer le portage Haxe du premier module dès l’étape suivante.

--- a/docs/STEP_BY_STEP_HAXE_TO_TS.md
+++ b/docs/STEP_BY_STEP_HAXE_TO_TS.md
@@ -1,0 +1,83 @@
+# Migration Frutiparc: approche 2 (Haxe -> convergence TypeScript)
+
+Ce document lance l’approche que vous avez validée: **porter d’abord la logique en Haxe**, puis converger progressivement vers un socle **TypeScript/Node.js**.
+
+## Étape 1 (maintenant) — Inventaire automatique du code AS2
+
+### Objectif
+Obtenir une cartographie exploitable des sources ActionScript (fichiers, classes, dépendances et APIs Flash sensibles).
+
+### Commande
+```bash
+node tools/migration/inventory_as2.js
+```
+
+### Résultat
+- Génère `migration/inventory/as2-inventory.json`.
+- Ce JSON servira de base pour prioriser le portage Haxe module par module.
+
+## Étape 2 — Définir les lots de portage Haxe
+
+À partir de l’inventaire:
+1. Classer les modules par criticité (auth, session, chat, inventaire, mini-jeux).
+2. Identifier ceux qui dépendent le plus du runtime Flash (`attachMovie`, `loadMovie`, `onClipEvent`) pour les traiter à part.
+3. Créer 3 lots:
+   - **Lot A (métier pur)**: portable rapidement en Haxe.
+   - **Lot B (métier + I/O)**: nécessite adaptateurs.
+   - **Lot C (UI/Flash direct)**: à réécrire côté client TypeScript/PixiJS.
+
+## Étape 3 — Créer le noyau Haxe
+
+Créer un module `packages/core-haxe` avec:
+- modèles de domaine (User, Room, Item, etc.),
+- services métier purs,
+- tests unitaires de non-régression.
+
+Cible recommandée au départ: **JavaScript** (pour intégration rapide au futur client/server TS).
+
+## Étape 4 — Brancher le noyau Haxe dans une app Node.js
+
+- Exposer les fonctions Haxe compilées JS dans `apps/api`.
+- Ajouter une couche anti-corruption qui convertit les anciens formats Frutiparc vers des DTO modernes.
+- Couvrir par des tests de contrat (entrées/sorties attendues).
+
+## Étape 5 — Convergence TypeScript progressive
+
+Pour chaque module Haxe stabilisé:
+1. Réécrire en TypeScript avec tests équivalents.
+2. Exécuter les deux implémentations en parallèle derrière un feature flag.
+3. Retirer la version Haxe après validation métriques + QA.
+
+## Définition de “Done” par module
+
+- Parité fonctionnelle validée.
+- Tests unitaires + contrat verts.
+- Aucun appel direct au runtime Flash dans le module.
+- Observabilité en place (logs + métriques d’erreur).
+
+## Prochaine exécution immédiate
+
+1. Lancer `node tools/migration/inventory_as2.js`.
+2. Ouvrir `migration/inventory/as2-inventory.json`.
+3. Choisir ensemble le **Lot A** (3 à 5 modules) pour commencer le portage Haxe.
+
+## Étape 2bis (outillage prêt) — Sélection automatique du Lot A
+
+Commande:
+```bash
+node tools/migration/select_lot_a.js
+```
+
+Sorties:
+- `migration/inventory/lot-a-candidates.json`
+- `docs/MVP_LOT_A.md`
+
+## Pour tester facilement (débutant)
+
+- Guide simple: `docs/COMMENT_TESTER.md`
+- Commande unique: `bash tools/migration/run_mvp.sh`
+
+## Lot A lancé (implémentation)
+
+- Premier portage réalisé: `FEColor`.
+- Voir `docs/LOT_A_PROGRESS.md` pour les commandes de test et la suite.

--- a/migration/inventory/as2-inventory.json
+++ b/migration/inventory/as2-inventory.json
@@ -1,0 +1,1062 @@
+{
+  "summary": {
+    "generatedAt": "2026-03-29T16:16:17.620Z",
+    "fileCount": 81,
+    "totalLines": 14102,
+    "filesWithOnClipEvent": 0,
+    "filesWithAttachMovie": 9,
+    "filesWithLoadMovie": 2,
+    "filesWithXml": 11
+  },
+  "files": [
+    {
+      "file": "frutiengine/Array.class.as",
+      "lines": 255,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/CBee.as",
+      "lines": 296,
+      "classes": [
+        "CBee"
+      ],
+      "extends": [
+        "XMLSocket"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": true
+    },
+    {
+      "file": "frutiengine/CBeeLC.as",
+      "lines": 21,
+      "classes": [
+        "CBeeLC"
+      ],
+      "extends": [
+        "LocalConnection"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/CBeeManager.as",
+      "lines": 188,
+      "classes": [
+        "CBeeManager"
+      ],
+      "extends": [
+        "LocalConnection"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": true
+    },
+    {
+      "file": "frutiengine/Desktop.as",
+      "lines": 20,
+      "classes": [
+        "Desktop"
+      ],
+      "extends": [
+        "Slot"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/FECMItem.as",
+      "lines": 18,
+      "classes": [
+        "FECMItem"
+      ],
+      "extends": [
+        "ContextMenuItem"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/FEColor.as",
+      "lines": 19,
+      "classes": [
+        "FEColor"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/FEDate.as",
+      "lines": 138,
+      "classes": [
+        "FEDate"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/FEMC.as",
+      "lines": 386,
+      "classes": [
+        "FEMC"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": true,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/FEMCLoader.as",
+      "lines": 51,
+      "classes": [
+        "FEMCLoader"
+      ],
+      "extends": [
+        "MovieClipLoader"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/FENumber.as",
+      "lines": 117,
+      "classes": [
+        "FENumber"
+      ],
+      "extends": [
+        "ext.util.MTNumber"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/FEObject.as",
+      "lines": 44,
+      "classes": [
+        "FEObject"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/FEString.as",
+      "lines": 491,
+      "classes": [
+        "FEString"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": true
+    },
+    {
+      "file": "frutiengine/FFileMng.as",
+      "lines": 113,
+      "classes": [
+        "FFileMng"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/FileLoader.as",
+      "lines": 165,
+      "classes": [
+        "FileLoader"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/frusion_content/CBeeLocal.as",
+      "lines": 77,
+      "classes": [
+        "CBeeLocal"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/frusion_external/CBeeLocal.as",
+      "lines": 194,
+      "classes": [
+        "CBeeLocal"
+      ],
+      "extends": [
+        "LocalConnection"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": true
+    },
+    {
+      "file": "frutiengine/frusion_internal/CBeeLocal.as",
+      "lines": 183,
+      "classes": [
+        "CBeeLocal"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": true
+    },
+    {
+      "file": "frutiengine/HTTP.as",
+      "lines": 159,
+      "classes": [
+        "HTTP"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": true
+    },
+    {
+      "file": "frutiengine/Lang.as",
+      "lines": 168,
+      "classes": [
+        "Lang"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/MD5.as",
+      "lines": 185,
+      "classes": [
+        "MD5"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/MovieClip.class.as",
+      "lines": 346,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": true,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/Pref.as",
+      "lines": 177,
+      "classes": [
+        "Pref"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/RunDate.as",
+      "lines": 75,
+      "classes": [
+        "RunDate"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/Slot.as",
+      "lines": 184,
+      "classes": [
+        "Slot"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/SlotList.as",
+      "lines": 85,
+      "classes": [
+        "SlotList"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/StatusMng.as",
+      "lines": 79,
+      "classes": [
+        "StatusMng"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/Tab.as",
+      "lines": 31,
+      "classes": [
+        "Tab"
+      ],
+      "extends": [
+        "Slot"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/TextField.class.as",
+      "lines": 46,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/UserListMng.as",
+      "lines": 207,
+      "classes": [
+        "UserListMng"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/UserMng.as",
+      "lines": 214,
+      "classes": [
+        "UserMng"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/WinBox.as",
+      "lines": 101,
+      "classes": [
+        "WinBox"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/Window.as",
+      "lines": 13,
+      "classes": [
+        "Window"
+      ],
+      "extends": [
+        "MovieClip"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiengine/WinStandard.as",
+      "lines": 732,
+      "classes": [
+        "WinStandard"
+      ],
+      "extends": [
+        "Window"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": true,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/BlackList.as",
+      "lines": 60,
+      "classes": [
+        "BlackList"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/cmdList.as",
+      "lines": 8,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/cmdList2.as",
+      "lines": 85,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/ContactList.as",
+      "lines": 73,
+      "classes": [
+        "ContactList"
+      ],
+      "extends": [
+        "IconFileBox"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/ContactListCache.as",
+      "lines": 51,
+      "classes": [
+        "ContactListCache"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/Depths.as",
+      "lines": 43,
+      "classes": [
+        "Depths"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/first.as",
+      "lines": 32,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": true,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/FPCBee.as",
+      "lines": 587,
+      "classes": [
+        "FPCBee"
+      ],
+      "extends": [
+        "CBee"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": true
+    },
+    {
+      "file": "frutiparc/FPCBeeManager.as",
+      "lines": 21,
+      "classes": [
+        "FPCBeeManager"
+      ],
+      "extends": [
+        "CBeeManager"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/FPDesktop.as",
+      "lines": 330,
+      "classes": [
+        "FPDesktop"
+      ],
+      "extends": [
+        "Desktop"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": true,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/FPFileMng.as",
+      "lines": 536,
+      "classes": [
+        "FPFileMng"
+      ],
+      "extends": [
+        "FFileMng"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/FPForumSlot.as",
+      "lines": 94,
+      "classes": [
+        "FPForumSlot"
+      ],
+      "extends": [
+        "Slot"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": true,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/FPPlugin.class.as",
+      "lines": 207,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/FPSlotList.as",
+      "lines": 91,
+      "classes": [
+        "FPSlotList"
+      ],
+      "extends": [
+        "SlotList"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/FPString.as",
+      "lines": 37,
+      "classes": [
+        "FPString"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/FPTab.as",
+      "lines": 92,
+      "classes": [
+        "FPTab"
+      ],
+      "extends": [
+        "Tab"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/FPTopDesktop.as",
+      "lines": 57,
+      "classes": [
+        "FPTopDesktop"
+      ],
+      "extends": [
+        "FPDesktop"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/FPTrashSlot.as",
+      "lines": 16,
+      "classes": [
+        "FPTrashSlot"
+      ],
+      "extends": [
+        "Slot"
+      ],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/FrutizInfo.as",
+      "lines": 516,
+      "classes": [
+        "FrutizInfo"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": true
+    },
+    {
+      "file": "frutiparc/global.as",
+      "lines": 299,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/IconFileBox.as",
+      "lines": 193,
+      "classes": [
+        "IconFileBox"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/init_final.as",
+      "lines": 26,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/init.as",
+      "lines": 264,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": true,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/InviteMng.as",
+      "lines": 54,
+      "classes": [
+        "InviteMng"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/lang_french.as",
+      "lines": 899,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": true
+    },
+    {
+      "file": "frutiparc/lib/box/init.as",
+      "lines": 41,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/lib/fe/init.as",
+      "lines": 40,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/lib/frusion/init.as",
+      "lines": 18,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/lib/interface/init.as",
+      "lines": 155,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/lib/listener/init.as",
+      "lines": 16,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/lib/root/init.as",
+      "lines": 28,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/lib/unsorted/init.as",
+      "lines": 78,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/listener/dragIconMouse.as",
+      "lines": 50,
+      "classes": [
+        "listener"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/listener/key.as",
+      "lines": 16,
+      "classes": [
+        "listener"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/listener/main.as",
+      "lines": 1225,
+      "classes": [
+        "listener"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/listener/mouse.as",
+      "lines": 12,
+      "classes": [
+        "listener"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/loading.as",
+      "lines": 103,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": true,
+      "hasLoadMovie": true,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/main/classLoader.as",
+      "lines": 60,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/MeMng.as",
+      "lines": 264,
+      "classes": [
+        "MeMng"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/openFunctions.as",
+      "lines": 660,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": true,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/Path.as",
+      "lines": 68,
+      "classes": [
+        "Path"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/registerSymphony.as",
+      "lines": 138,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/Standard.as",
+      "lines": 569,
+      "classes": [
+        "Standard"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": true
+    },
+    {
+      "file": "frutiparc/test_game/CBeeLocal.as",
+      "lines": 72,
+      "classes": [
+        "CBeeLocal"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/test_game/init.as",
+      "lines": 28,
+      "classes": [],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    },
+    {
+      "file": "frutiparc/TipTextMng.as",
+      "lines": 84,
+      "classes": [
+        "TipTextMng"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": true,
+      "hasLoadMovie": false,
+      "hasXml": true
+    },
+    {
+      "file": "frutiparc/WallPaperMng.as",
+      "lines": 128,
+      "classes": [
+        "WallPaperMng"
+      ],
+      "extends": [],
+      "imports": [],
+      "hasOnClipEvent": false,
+      "hasAttachMovie": false,
+      "hasLoadMovie": false,
+      "hasXml": false
+    }
+  ]
+}

--- a/migration/inventory/lot-a-candidates.json
+++ b/migration/inventory/lot-a-candidates.json
@@ -1,0 +1,85 @@
+{
+  "generatedAt": "2026-03-29T16:16:17.693Z",
+  "strategy": "Haxe-first migration: select low-Flash-dependency business logic modules",
+  "sourceInventory": "migration/inventory/as2-inventory.json",
+  "candidates": [
+    {
+      "file": "frutiengine/Window.as",
+      "score": 14,
+      "lines": 13,
+      "classes": [
+        "Window"
+      ],
+      "extends": [
+        "MovieClip"
+      ],
+      "importsCount": 0,
+      "hasXml": false,
+      "reasons": [
+        "has class declaration"
+      ]
+    },
+    {
+      "file": "frutiengine/FECMItem.as",
+      "score": 14,
+      "lines": 18,
+      "classes": [
+        "FECMItem"
+      ],
+      "extends": [
+        "ContextMenuItem"
+      ],
+      "importsCount": 0,
+      "hasXml": false,
+      "reasons": [
+        "has class declaration"
+      ]
+    },
+    {
+      "file": "frutiengine/FEColor.as",
+      "score": 14,
+      "lines": 19,
+      "classes": [
+        "FEColor"
+      ],
+      "extends": [],
+      "importsCount": 0,
+      "hasXml": false,
+      "reasons": [
+        "has class declaration"
+      ]
+    },
+    {
+      "file": "frutiengine/Desktop.as",
+      "score": 14,
+      "lines": 20,
+      "classes": [
+        "Desktop"
+      ],
+      "extends": [
+        "Slot"
+      ],
+      "importsCount": 0,
+      "hasXml": false,
+      "reasons": [
+        "has class declaration"
+      ]
+    },
+    {
+      "file": "frutiengine/CBeeLC.as",
+      "score": 14,
+      "lines": 21,
+      "classes": [
+        "CBeeLC"
+      ],
+      "extends": [
+        "LocalConnection"
+      ],
+      "importsCount": 0,
+      "hasXml": false,
+      "reasons": [
+        "has class declaration"
+      ]
+    }
+  ]
+}

--- a/packages/core-haxe/src/frutiparc/core/CBee.hx
+++ b/packages/core-haxe/src/frutiparc/core/CBee.hx
@@ -1,0 +1,170 @@
+package frutiparc.core;
+
+/**
+ * Portage Haxe pragmatique de CBee (orchestration commandes/listeners).
+ * Source legacy: frutiengine/CBee.as
+ */
+class CBee {
+  public var listeners:Map<String, Array<Dynamic>>;
+  public var specificListeners:Map<String, Dynamic>;
+  public var cmdList:Map<String, String>;
+  public var host:String;
+  public var port:Int;
+  public var connected:Bool;
+  public var globalListener:Dynamic;
+  public var cnxNb:Int = 0;
+  public var sentLog:Array<Dynamic>;
+
+  public function new(?o:Dynamic = null) {
+    this.cmdList = new Map();
+    this.cmdList.set("onclose", "onclose");
+    this.cmdList.set("onconnect", "onconnect");
+
+    this.listeners = new Map();
+    this.specificListeners = new Map();
+    this.sentLog = [];
+    this.connected = false;
+
+    if (o != null) for (n in Reflect.fields(o)) Reflect.setField(this, n, Reflect.field(o, n));
+  }
+
+  public function debug(str:String):Void {}
+
+  public function connect(host:String, port:Int):Void {
+    this.host = host;
+    this.port = port;
+    this.connected = false;
+  }
+
+  public function onConnect(success:Bool):Void {
+    callGlobalListener("onConnect", success);
+    if (success) {
+      this.connected = true;
+      this.cnxNb++;
+    } else {
+      this.connected = false;
+    }
+    callListenersArray(this.listeners.get("onconnect"), success);
+  }
+
+  public function onClose():Void {
+    callGlobalListener("onClose", null);
+    this.connected = false;
+    callListenersArray(this.listeners.get("onclose"), null);
+  }
+
+  public function onXML(node:Dynamic):Void {
+    if (node == null) return;
+
+    var cmdName = Std.string(Reflect.field(node, "nodeName")).toLowerCase();
+    callListenersArray(this.listeners.get(cmdName), node);
+
+    var attrs:Dynamic = Reflect.field(node, "attributes");
+    if (attrs != null) {
+      for (attrib in Reflect.fields(attrs)) {
+        var byCmd = specificListeners.get(cmdName);
+        if (byCmd == null) continue;
+        var byAttr = Reflect.field(byCmd, attrib);
+        if (byAttr == null) continue;
+        var val = Std.string(Reflect.field(attrs, attrib));
+        callListenersArray(Reflect.field(byAttr, val), node);
+      }
+    }
+
+    callGlobalListener("onXML", node);
+  }
+
+  public function setGlobalListener(obj:Dynamic):Void {
+    this.globalListener = obj;
+  }
+
+  public function callGlobalListener(event:String, data:Dynamic):Void {
+    if (this.globalListener == null) return;
+    this.globalListener.obj[this.globalListener.method](this.port, event, data);
+  }
+
+  public function send(x:Dynamic):Bool {
+    if (!this.connected) return false;
+    this.sentLog.push(x);
+    return true;
+  }
+
+  public function cmd(cmd:String, attr:Dynamic, ?child:Dynamic = null):Bool {
+    var cbeeCmdName = this.cmdList.get(Std.string(cmd).toLowerCase());
+    if (cbeeCmdName == null) return false;
+
+    var x:Dynamic = {nodeName: cbeeCmdName, attributes: {}};
+    if (attr != null) for (n in Reflect.fields(attr)) Reflect.setField(x.attributes, n, Reflect.field(attr, n));
+
+    if (child != null) Reflect.setField(x, "child", child);
+
+    return this.send(x);
+  }
+
+  public function addListener(cmd:String, obj:Dynamic, method:String, ?attrib:String = null, ?value:Dynamic = null):Void {
+    var c = Std.string(cmd).toLowerCase();
+    var cbeeCmd = this.cmdList.get(c);
+    if (cbeeCmd == null) return;
+
+    if (attrib == null) {
+      var arr = this.listeners.get(cbeeCmd);
+      if (arr == null) {
+        arr = [];
+        this.listeners.set(cbeeCmd, arr);
+      }
+      arr.push({obj: obj, method: method});
+    } else {
+      if (!this.specificListeners.exists(cbeeCmd)) this.specificListeners.set(cbeeCmd, {});
+      var byCmd = this.specificListeners.get(cbeeCmd);
+      if (Reflect.field(byCmd, attrib) == null) Reflect.setField(byCmd, attrib, {});
+      var byAttr = Reflect.field(byCmd, attrib);
+      var key = Std.string(value);
+      if (Reflect.field(byAttr, key) == null) Reflect.setField(byAttr, key, []);
+      Reflect.field(byAttr, key).push({obj: obj, method: method});
+    }
+  }
+
+  public function removeListenerCmd(cmd:String, ?attrib:String = null, ?value:Dynamic = null):Void {
+    var cbeeCmd = this.cmdList.get(Std.string(cmd).toLowerCase());
+    if (cbeeCmd == null) return;
+    if (attrib == null) {
+      this.listeners.set(cbeeCmd, []);
+    } else {
+      var byCmd = this.specificListeners.get(cbeeCmd);
+      if (byCmd == null) return;
+      var byAttr = Reflect.field(byCmd, attrib);
+      if (byAttr == null) return;
+      Reflect.setField(byAttr, Std.string(value), []);
+    }
+  }
+
+  public function removeListenerCmdObj(cmd:String, obj:Dynamic, ?attrib:String = null, ?value:Dynamic = null):Void {
+    var cbeeCmd = this.cmdList.get(Std.string(cmd).toLowerCase());
+    if (cbeeCmd == null) return;
+    if (attrib == null) {
+      var arr = this.listeners.get(cbeeCmd);
+      if (arr == null) return;
+      filterObj(arr, obj);
+    } else {
+      var byCmd = this.specificListeners.get(cbeeCmd);
+      if (byCmd == null) return;
+      var byAttr = Reflect.field(byCmd, attrib);
+      if (byAttr == null) return;
+      var arr2:Array<Dynamic> = Reflect.field(byAttr, Std.string(value));
+      if (arr2 == null) return;
+      filterObj(arr2, obj);
+    }
+  }
+
+  public function callListenersArray(arr:Array<Dynamic>, node:Dynamic):Void {
+    if (arr == null) return;
+    for (l in arr) l.obj[l.method](node);
+  }
+
+  function filterObj(arr:Array<Dynamic>, obj:Dynamic):Void {
+    var i = 0;
+    while (i < arr.length) {
+      if (arr[i].obj == obj) arr.splice(i, 1); else i++;
+    }
+  }
+}

--- a/packages/core-haxe/src/frutiparc/core/CBeeLC.hx
+++ b/packages/core-haxe/src/frutiparc/core/CBeeLC.hx
@@ -1,0 +1,26 @@
+package frutiparc.core;
+
+/**
+ * Portage Haxe du module AS2 CBeeLC.
+ * Source legacy: frutiengine/CBeeLC.as
+ */
+class CBeeLC {
+  public var cbee:CBeeLike;
+
+  public function new(cbee:CBeeLike) {
+    this.cbee = cbee;
+  }
+
+  public function send(x:Dynamic):Dynamic {
+    return this.cbee.send(x);
+  }
+
+  public function cmd(a:Dynamic, b:Dynamic, c:Dynamic):Dynamic {
+    return this.cbee.cmd(a, b, c);
+  }
+}
+
+interface CBeeLike {
+  public function send(x:Dynamic):Dynamic;
+  public function cmd(a:Dynamic, b:Dynamic, c:Dynamic):Dynamic;
+}

--- a/packages/core-haxe/src/frutiparc/core/CBeeLocal.hx
+++ b/packages/core-haxe/src/frutiparc/core/CBeeLocal.hx
@@ -1,0 +1,240 @@
+package frutiparc.core;
+
+/**
+ * Portage Haxe pragmatique de CBeeLocal.
+ * Supporte les variantes internes (CBeeManager) et externes (LocalConnection).
+ */
+class CBeeLocal {
+  public var cmdList:Map<String, String>;
+  public var listeners:Map<String, Array<Dynamic>>;
+  public var specificListeners:Map<String, Dynamic>;
+  public var initialized:Bool;
+  public var connected:Bool;
+  public var logged:Bool;
+  public var port:Int;
+  public var cbeeLC:Dynamic;
+  public var cbeeManager:Dynamic;
+
+  // External variant fields
+  public var sid:Dynamic;
+  public var lcName:String;
+  public var managerChannel:String;
+  public var serverChannel:String;
+  public var inboundConnection:Dynamic;
+  public var localConnectionFactory:Dynamic;
+
+  public function new(?obj:Dynamic = null) {
+    this.cmdList = new Map();
+    this.cmdList.set("onclose", "onclose");
+    this.cmdList.set("onconnect", "onconnect");
+    this.cmdList.set("ident", "ident");
+
+    this.listeners = new Map();
+    this.specificListeners = new Map();
+    this.initialized = false;
+    this.connected = false;
+    this.logged = false;
+
+    if (obj != null) for (n in Reflect.fields(obj)) Reflect.setField(this, n, Reflect.field(obj, n));
+
+    this.addListener("ident", this, "onIdent");
+  }
+
+  inline function isInternalMode():Bool {
+    return this.cbeeManager != null;
+  }
+
+  static function randomId():String {
+    return StringTools.replace(Std.string(Math.random()), "0.", "");
+  }
+
+  public function init():Void {
+    if (this.port == null) return;
+
+    if (isInternalMode()) {
+      this.initialized = true;
+      this.cbeeLC = this.cbeeManager.addListener(this.port, this, true);
+
+      var obj = this.cbeeManager.getStatus(this.port);
+      if (obj != null && obj.connected) this.onConnect(true);
+      if (obj != null && obj.logged) this.callListenersArray(this.listeners.get(this.cmdList.get("ident")), null);
+      return;
+    }
+
+    if (this.sid == null || this.localConnectionFactory == null) return;
+    if (this.lcName == null) this.lcName = 'fp_cblc_${this.sid}_${this.port}_${randomId()}';
+    if (this.managerChannel == null) this.managerChannel = 'fp_cbeeMng_${this.sid}';
+
+    if (this.inboundConnection != null && Reflect.field(this.inboundConnection, "connect") != null) {
+      this.inboundConnection.connect(this.lcName);
+    }
+
+    var lc = this.localConnectionFactory();
+    lc.obj = this;
+    lc.onStatus = function(obj:Dynamic) {
+      if (obj != null && obj.level == "error") this.looseLocalConnection();
+      else this.initialized = true;
+    };
+    lc.send(this.managerChannel, "addListener", this.port, this.lcName);
+    lc.send(this.managerChannel, "getStatus", this.port, this.lcName);
+  }
+
+  public function close():Void {
+    if (this.cbeeManager != null) this.cbeeManager.removeListener(this.port, this);
+  }
+
+  public function check():Void {}
+
+  public function looseLocalConnection():Void {
+    this.initialized = false;
+    this.onClose();
+  }
+
+  public function onConnect(success:Bool):Void {
+    this.connected = success;
+    this.logged = false;
+    this.callListenersArray(this.listeners.get("onconnect"), success);
+  }
+
+  public function onClose():Void {
+    this.connected = false;
+    this.logged = false;
+    this.callListenersArray(this.listeners.get("onclose"), null);
+  }
+
+  public function onXML(node:Dynamic):Void {
+    if (node == null) return;
+    var cmdName = Std.string(node.nodeName).toLowerCase();
+    callListenersArray(this.listeners.get(cmdName), node);
+
+    var attrs:Dynamic = Reflect.field(node, "attributes");
+    if (attrs != null) {
+      for (attrib in Reflect.fields(attrs)) {
+        var byCmd = specificListeners.get(cmdName);
+        if (byCmd == null) continue;
+        var byAttr = Reflect.field(byCmd, attrib);
+        if (byAttr == null) continue;
+        callListenersArray(Reflect.field(byAttr, Std.string(Reflect.field(attrs, attrib))), node);
+      }
+    }
+  }
+
+  public function onStatus(obj:Dynamic):Void {
+    if (obj != null && obj.connected) this.onConnect(true);
+    this.logged = obj != null && obj.logged == true;
+  }
+
+  public function send(s:Dynamic):Bool {
+    if (isInternalMode()) {
+      if (!this.initialized) return false;
+      if (this.cbeeLC == null || Reflect.field(this.cbeeLC, "send") == null) return false;
+      this.cbeeLC.send(s);
+      return true;
+    }
+
+    if (!this.initialized || !this.connected || this.localConnectionFactory == null) return false;
+    var lc = this.localConnectionFactory();
+    lc.obj = this;
+    lc.onStatus = function(obj:Dynamic) {
+      if (obj != null && obj.level == "error") this.looseLocalConnection();
+    };
+    var channel = this.serverChannel != null ? this.serverChannel : 'fp_cbee_${this.port}_${this.sid}';
+    lc.send(channel, "send", s);
+    return true;
+  }
+
+  public function cmd(cmd:String, attr:Dynamic, ?child:Dynamic = null):Bool {
+    if (!isInternalMode()) {
+      if (!this.initialized || !this.connected || this.localConnectionFactory == null) return false;
+      var lc = this.localConnectionFactory();
+      lc.obj = this;
+      lc.onStatus = function(obj:Dynamic) {
+        if (obj != null && obj.level == "error") this.looseLocalConnection();
+      };
+      var channel = this.serverChannel != null ? this.serverChannel : 'fp_cbee_${this.port}_${this.sid}';
+      lc.send(channel, "cmd", cmd, attr, child);
+      return true;
+    }
+
+    var cbeeCmdName = this.cmdList.get(Std.string(cmd).toLowerCase());
+    if (cbeeCmdName == null) return false;
+
+    var x:Dynamic = {nodeName: cbeeCmdName, attributes: {}};
+    if (attr != null) for (n in Reflect.fields(attr)) Reflect.setField(x.attributes, n, Reflect.field(attr, n));
+    if (child != null) Reflect.setField(x, "child", child);
+    return this.send(x);
+  }
+
+  public function onIdent(node:Dynamic):Void {
+    this.connected = true;
+    if (node == null || node.attributes == null || node.attributes.k == null) this.logged = true;
+    else this.logged = false;
+  }
+
+  public function addListener(cmd:String, obj:Dynamic, method:String, ?attrib:String = null, ?value:Dynamic = null):Void {
+    var cbeeCmd = this.cmdList.get(Std.string(cmd).toLowerCase());
+    if (cbeeCmd == null) return;
+
+    if (attrib == null) {
+      var arr = this.listeners.get(cbeeCmd);
+      if (arr == null) {
+        arr = [];
+        this.listeners.set(cbeeCmd, arr);
+      }
+      arr.push({obj: obj, method: method});
+    } else {
+      if (!this.specificListeners.exists(cbeeCmd)) this.specificListeners.set(cbeeCmd, {});
+      var byCmd = this.specificListeners.get(cbeeCmd);
+      if (Reflect.field(byCmd, attrib) == null) Reflect.setField(byCmd, attrib, {});
+      var byAttr = Reflect.field(byCmd, attrib);
+      var key = Std.string(value);
+      if (Reflect.field(byAttr, key) == null) Reflect.setField(byAttr, key, []);
+      Reflect.field(byAttr, key).push({obj: obj, method: method});
+    }
+  }
+
+  public function removeListenerCmd(cmd:String, ?attrib:String = null, ?value:Dynamic = null):Void {
+    var cbeeCmd = this.cmdList.get(Std.string(cmd).toLowerCase());
+    if (cbeeCmd == null) return;
+
+    if (attrib == null) this.listeners.set(cbeeCmd, []);
+    else {
+      var byCmd = this.specificListeners.get(cbeeCmd);
+      if (byCmd == null) return;
+      var byAttr = Reflect.field(byCmd, attrib);
+      if (byAttr == null) return;
+      Reflect.setField(byAttr, Std.string(value), []);
+    }
+  }
+
+  public function removeListenerCmdObj(cmd:String, obj:Dynamic, ?attrib:String = null, ?value:Dynamic = null):Void {
+    var cbeeCmd = this.cmdList.get(Std.string(cmd).toLowerCase());
+    if (cbeeCmd == null) return;
+
+    if (attrib == null) {
+      var arr = this.listeners.get(cbeeCmd);
+      if (arr == null) return;
+      filterObj(arr, obj);
+    } else {
+      var byCmd = this.specificListeners.get(cbeeCmd);
+      if (byCmd == null) return;
+      var byAttr = Reflect.field(byCmd, attrib);
+      if (byAttr == null) return;
+      var arr2:Array<Dynamic> = Reflect.field(byAttr, Std.string(value));
+      if (arr2 == null) return;
+      filterObj(arr2, obj);
+    }
+  }
+
+  public function callListenersArray(arr:Array<Dynamic>, node:Dynamic):Void {
+    if (arr == null) return;
+    for (l in arr) l.obj[l.method](node);
+  }
+
+  function filterObj(arr:Array<Dynamic>, obj:Dynamic):Void {
+    var i = 0;
+    while (i < arr.length) {
+      if (arr[i].obj == obj) arr.splice(i, 1); else i++;
+    }
+  }
+}

--- a/packages/core-haxe/src/frutiparc/core/CBeeManager.hx
+++ b/packages/core-haxe/src/frutiparc/core/CBeeManager.hx
@@ -1,0 +1,114 @@
+package frutiparc.core;
+
+/**
+ * Portage Haxe pragmatique de CBeeManager.
+ * Focus: orchestration des connexions CBee + listeners (sans LocalConnection Flash).
+ */
+class CBeeManager {
+  public var className:String = "CBee";
+  public var timeout:Int = 1000;
+  public var cnxTimeout:Int = 60000;
+  public var cbeeCnx:Map<String, Dynamic>;
+  public var now:Void->Float;
+  public var host:String;
+
+  public function new(?o:Dynamic = null) {
+    this.cbeeCnx = new Map();
+    this.now = function() return Date.now().getTime();
+    this.host = "localhost";
+
+    if (o != null) for (n in Reflect.fields(o)) Reflect.setField(this, n, Reflect.field(o, n));
+  }
+
+  public function addListener(port:Int, lc:Dynamic, ?notRecallMe:Bool = false):Dynamic {
+    if (lc == null) return null;
+    var key = Std.string(port);
+
+    if (!cbeeCnx.exists(key)) {
+      addCnx(port, false, null);
+    } else if (!cbeeCnx.get(key).cbee.connected) {
+      cbeeCnx.get(key).cbee.connect(this.host, port);
+    }
+
+    var listeners:Array<Dynamic> = cbeeCnx.get(key).listeners;
+    if (listeners.indexOf(lc) == -1) listeners.push(lc);
+
+    return cbeeCnx.get(key).lc;
+  }
+
+  public function getStatus(port:Int, lc:Dynamic):Dynamic {
+    var cc = cbeeCnx.get(Std.string(port));
+    if (cc == null) return null;
+
+    var obj = {
+      connected: cc.cbee.connected,
+      logged: Reflect.field(cc.cbee, "logged") == true,
+    };
+
+    if (lc != null && Reflect.field(lc, "onStatus") != null) lc.onStatus(obj);
+    return obj;
+  }
+
+  public function removeListener(port:Int, lc:Dynamic, ?forceClose:Bool = false):Void {
+    var cc = cbeeCnx.get(Std.string(port));
+    if (cc == null) return;
+
+    var i = cc.listeners.indexOf(lc);
+    if (i >= 0) cc.listeners.splice(i, 1);
+
+    if (cc.listeners.length == 0) {
+      if (forceClose) removeCnx(port);
+      else cc.emptyTime = now();
+    }
+  }
+
+  public function addCnx(port:Int, ?force:Bool = false, ?obj:Dynamic = null):Dynamic {
+    var cbee = new CBee(obj);
+    cbee.connect(this.host, port);
+    cbee.setGlobalListener({obj: this, method: "onGlobalListener"});
+
+    var lc = new CBeeLC(cbee);
+
+    cbeeCnx.set(Std.string(port), {
+      cbee: cbee,
+      lc: lc,
+      listeners: [],
+      emptyTime: now(),
+      force: force,
+    });
+
+    return cbee;
+  }
+
+  public function removeCnx(port:Int):Void {
+    var key = Std.string(port);
+    var cc = cbeeCnx.get(key);
+    if (cc == null) return;
+
+    cc.cbee.setGlobalListener(null);
+    cbeeCnx.remove(key);
+  }
+
+  public function onGlobalListener(port:Int, event:String, data:Dynamic):Void {
+    var cc = cbeeCnx.get(Std.string(port));
+    if (cc == null) return;
+
+    if (event == "onClose" && !cc.force && cc.listeners.length == 0) {
+      removeCnx(port);
+      return;
+    }
+
+    for (e in cc.listeners) {
+      if (e != null && Reflect.field(e, event) != null) Reflect.callMethod(e, Reflect.field(e, event), [data]);
+    }
+  }
+
+  public function checkAll():Void {
+    for (port in cbeeCnx.keys()) {
+      var cc = cbeeCnx.get(port);
+      if (!cc.force && cc.listeners.length == 0 && now() - cc.emptyTime > cnxTimeout) {
+        removeCnx(Std.parseInt(port));
+      }
+    }
+  }
+}

--- a/packages/core-haxe/src/frutiparc/core/ClassLoader.hx
+++ b/packages/core-haxe/src/frutiparc/core/ClassLoader.hx
@@ -1,0 +1,101 @@
+package frutiparc.core;
+
+/**
+ * Portage pragmatique de frutiparc/main/classLoader.as
+ * (orchestration de chargement séquentiel des bibliothèques .swf).
+ */
+class ClassLoader {
+  public var libPath:Array<String>;
+  public var baseUrl:String;
+  public var logText:String;
+  public var libToLoad:Int;
+  public var libLoaded:Int;
+  public var state:String;
+  public var clips:Map<String, Dynamic>;
+  public var loader:Dynamic;
+  public var onPlay:Void->Void;
+
+  public function new(?obj:Dynamic = null) {
+    this.libPath = [
+      "bumdum.swf",
+      "skool.swf",
+      "fe.swf",
+      "box.swf",
+      "root.swf",
+      "frusion.swf",
+      "interface.swf",
+      "listener.swf",
+      "unsorted.swf"
+    ];
+    this.baseUrl = "http://www.beta.frutiparc.com/swf/lib/";
+    this.logText = "";
+    this.libToLoad = this.libPath.length;
+    this.libLoaded = 0;
+    this.state = "stopped";
+    this.clips = new Map();
+
+    if (obj != null) for (n in Reflect.fields(obj)) Reflect.setField(this, n, Reflect.field(obj, n));
+
+    if (this.loader != null) this.attachLoaderListeners(this.loader);
+  }
+
+  public function attachLoaderListeners(loader:Dynamic):Void {
+    this.loader = loader;
+    if (loader != null && Reflect.field(loader, "addListener") != null) loader.addListener(this);
+  }
+
+  public function play():Void {
+    this.state = "playing";
+    if (this.onPlay != null) this.onPlay();
+  }
+
+  public function stop():Void {
+    this.state = "stopped";
+  }
+
+  public function createEmptyMovieClip(name:String, depth:Int):Dynamic {
+    var mc:Dynamic = {name: name, depth: depth, url: null};
+    this.clips.set(name, mc);
+    return mc;
+  }
+
+  public function initLoad(id:Int):Dynamic {
+    var name = 'lib$id';
+    var mc = createEmptyMovieClip(name, 80 + id);
+    var url = this.baseUrl + this.libPath[id];
+    mc.url = url;
+
+    if (this.loader != null && Reflect.field(this.loader, "loadClip") != null) {
+      this.loader.loadClip(url, mc);
+    }
+
+    return {mc: mc, url: url};
+  }
+
+  public function start():Dynamic {
+    this.stop();
+    this.libToLoad = this.libPath.length;
+    this.libLoaded = 0;
+    this.logText = "";
+    return initLoad(0);
+  }
+
+  public function onLoadComplete(mc:Dynamic):Void {
+    this.logText += 'loadComplete(${Reflect.field(mc, "name") != null ? Reflect.field(mc, "name") : Std.string(mc)})\n';
+    this.libLoaded++;
+
+    if (this.libLoaded >= this.libToLoad) {
+      this.play();
+    } else {
+      this.initLoad(this.libLoaded);
+    }
+  }
+
+  public function onLoadError(mc:Dynamic, error:Dynamic):Void {
+    this.logText += 'loadError(${Std.string(error)})\n';
+  }
+
+  public function onLoadStart(mc:Dynamic):Void {
+    this.logText += 'loadStart(${Reflect.field(mc, "name") != null ? Reflect.field(mc, "name") : Std.string(mc)})\n';
+  }
+}

--- a/packages/core-haxe/src/frutiparc/core/Desktop.hx
+++ b/packages/core-haxe/src/frutiparc/core/Desktop.hx
@@ -1,0 +1,19 @@
+package frutiparc.core;
+
+/**
+ * Portage Haxe du module AS2 Desktop.
+ * Source legacy: frutiengine/Desktop.as
+ */
+class Desktop extends SlotBase {
+  public var iconList:Array<Dynamic>;
+
+  public function new() {
+    super();
+    this.iconList = [];
+  }
+
+  public override function init(slotList:Dynamic, depth:Dynamic, flGo:Dynamic):Void {
+    super.init(slotList, depth, flGo);
+    this.iconList = [];
+  }
+}

--- a/packages/core-haxe/src/frutiparc/core/FECMItem.hx
+++ b/packages/core-haxe/src/frutiparc/core/FECMItem.hx
@@ -1,0 +1,38 @@
+package frutiparc.core;
+
+/**
+ * Portage Haxe du module AS2 FECMItem.
+ * Source legacy: frutiengine/FECMItem.as
+ */
+class FECMItem {
+  public var caption:String;
+  public var callBack:CallbackDescriptor;
+  public var flSeparatorBefore:Bool;
+  public var flEnabled:Bool;
+  public var flVisible:Bool;
+
+  public function new(
+    caption:String,
+    callBack:CallbackDescriptor,
+    flSeparatorBefore:Bool,
+    flEnabled:Bool,
+    flVisible:Bool
+  ) {
+    this.caption = caption;
+    this.callBack = callBack;
+    this.flSeparatorBefore = flSeparatorBefore;
+    this.flEnabled = flEnabled;
+    this.flVisible = flVisible;
+  }
+
+  public static function onSelect(mc:Dynamic, menuItem:FECMItem):Dynamic {
+    var fn = Reflect.field(menuItem.callBack.obj, menuItem.callBack.method);
+    return Reflect.callMethod(menuItem.callBack.obj, fn, [menuItem.callBack.args]);
+  }
+}
+
+typedef CallbackDescriptor = {
+  var obj:Dynamic;
+  var method:String;
+  var args:Dynamic;
+}

--- a/packages/core-haxe/src/frutiparc/core/FEColor.hx
+++ b/packages/core-haxe/src/frutiparc/core/FEColor.hx
@@ -1,0 +1,24 @@
+package frutiparc.core;
+
+/**
+ * Portage Haxe du module AS2 FEColor.
+ * Source legacy: frutiengine/FEColor.as
+ */
+class FEColor {
+  public static function toRGBObj(nb:Int):RGB {
+    var r = (nb >> 16) & 255;
+    var g = (nb >> 8) & 255;
+    var b = nb & 255;
+    return { r: r, g: g, b: b };
+  }
+
+  public static function toRGBInt(obj:RGB):Int {
+    return obj.r * 256 * 256 + obj.g * 256 + obj.b;
+  }
+}
+
+typedef RGB = {
+  var r:Int;
+  var g:Int;
+  var b:Int;
+}

--- a/packages/core-haxe/src/frutiparc/core/FEDate.hx
+++ b/packages/core-haxe/src/frutiparc/core/FEDate.hx
@@ -1,0 +1,84 @@
+package frutiparc.core;
+
+/**
+ * Portage Haxe (subset utile) du module AS2 FEDate.
+ * Source legacy: frutiengine/FEDate.as
+ */
+class FEDate {
+  public static function newFromString(str:String):Date {
+    var y = Std.parseInt(str.substr(0, 4));
+    var m = Std.parseInt(str.substr(5, 2));
+    var d = Std.parseInt(str.substr(8, 2));
+
+    var h = Std.parseInt(str.substr(11, 2));
+    var i = Std.parseInt(str.substr(14, 2));
+    var s = Std.parseInt(str.substr(17, 2));
+
+    var hh = (h == null) ? 0 : h;
+    var ii = (i == null) ? 0 : i;
+    var ss = (s == null) ? 0 : s;
+
+    return Date.fromTime(DateTools.makeUtc(y, m, d, hh, ii, ss));
+  }
+
+  public static function newFromTime(t:Float):Date {
+    return Date.fromTime(t);
+  }
+
+  public static function getObject(d:Date):DateObject {
+    return {
+      y: FENumber.toStringL(d.getFullYear(), 4),
+      m: FENumber.toStringL(d.getMonth() + 1, 2),
+      day: FENumber.toStringL(d.getDate(), 2),
+      h: FENumber.toStringL(d.getHours(), 2),
+      i: FENumber.toStringL(d.getMinutes(), 2),
+      s: FENumber.toStringL(d.getSeconds(), 2),
+    };
+  }
+
+  public static function getCompleteObject(d:Date):CompleteDateObject {
+    var b = d.getDay();
+    if (b == 0) b = 7;
+
+    return {
+      y: FENumber.toStringL(d.getFullYear() % 100, 2),
+      Y: FENumber.toStringL(d.getFullYear(), 4),
+      b: FENumber.toStringL(b, 1),
+      day: FENumber.toStringL(d.getDate(), 1),
+      D: FENumber.toStringL(d.getDate(), 2),
+      n: FENumber.toStringL(d.getMonth() + 1, 1),
+      N: FENumber.toStringL(d.getMonth() + 1, 2),
+      h: FENumber.toStringL(d.getHours(), 1),
+      H: FENumber.toStringL(d.getHours(), 2),
+      i: FENumber.toStringL(d.getMinutes(), 1),
+      I: FENumber.toStringL(d.getMinutes(), 2),
+      s: FENumber.toStringL(d.getSeconds(), 1),
+      S: FENumber.toStringL(d.getSeconds(), 2),
+    };
+  }
+}
+
+typedef DateObject = {
+  var y:String;
+  var m:String;
+  var day:String;
+  var h:String;
+  var i:String;
+  var s:String;
+}
+
+typedef CompleteDateObject = {
+  var y:String;
+  var Y:String;
+  var b:String;
+  var day:String;
+  var D:String;
+  var n:String;
+  var N:String;
+  var h:String;
+  var H:String;
+  var i:String;
+  var I:String;
+  var s:String;
+  var S:String;
+}

--- a/packages/core-haxe/src/frutiparc/core/FEMC.hx
+++ b/packages/core-haxe/src/frutiparc/core/FEMC.hx
@@ -1,0 +1,127 @@
+package frutiparc.core;
+
+/**
+ * Portage Haxe pragmatique de FEMC (helpers non-Flash critiques).
+ * Source legacy: frutiengine/FEMC.as
+ */
+class FEMC {
+  public static function setColor(mc:Dynamic, o:Dynamic, ?negFlag:Bool = false):Dynamic {
+    var col:Dynamic = null;
+    if (Reflect.field(o, "r") != null) {
+      var alpha = Reflect.field(o, "a");
+      if (alpha == null) alpha = 0;
+      col = {
+        rb: Reflect.field(o, "r"),
+        gb: Reflect.field(o, "g"),
+        bb: Reflect.field(o, "b"),
+        ab: alpha,
+      };
+    } else if (Std.isOfType(o, Int) || Std.isOfType(o, Float)) {
+      var n:Int = Std.int(o);
+      col = {
+        rb: (n >> 16) & 255,
+        gb: (n >> 8) & 255,
+        bb: n & 255,
+      };
+    } else {
+      return null;
+    }
+
+    if (negFlag) {
+      col.ra = -100;
+      col.ga = -100;
+      col.ba = -100;
+    } else {
+      col.ra = 100;
+      col.ga = 100;
+      col.ba = 100;
+      col.rb -= 255;
+      col.gb -= 255;
+      col.bb -= 255;
+    }
+
+    Reflect.setField(mc, "lastTransform", col);
+    return col;
+  }
+
+  public static function setPColor(mc:Dynamic, color:Dynamic, percent:Float):Dynamic {
+    var c = color;
+    if (Std.isOfType(color, Int) || Std.isOfType(color, Float)) {
+      c = FENumber.toColorObj(Std.int(color));
+    }
+
+    if (Reflect.field(mc, "colorObject") == null) {
+      Reflect.setField(mc, "colorObject", {
+        actual: {
+          col: {r: 0, g: 0, b: 0},
+          percent: 100,
+        }
+      });
+    }
+
+    if (c != null) {
+      Reflect.field(mc, "colorObject").actual = {col: c, percent: percent};
+    }
+
+    var act = Reflect.field(mc, "colorObject").actual;
+    var coef = (100 - act.percent) / 100;
+    var tr = {
+      ra: act.percent,
+      ga: act.percent,
+      ba: act.percent,
+      aa: 100,
+      rb: act.col.r * coef,
+      gb: act.col.g * coef,
+      bb: act.col.b * coef,
+      ab: 0,
+    };
+
+    Reflect.setField(mc, "lastTransform", tr);
+    return tr;
+  }
+
+  public static function killColor(mc:Dynamic):Dynamic {
+    var tr = {
+      ra: 100,
+      ga: 100,
+      ba: 100,
+      aa: 100,
+      rb: 0,
+      gb: 0,
+      bb: 0,
+      ab: 0,
+    };
+    Reflect.setField(mc, "lastTransform", tr);
+    return tr;
+  }
+
+  public static function morphToButton(mc:Dynamic):Void {
+    mc.onRollOver = function() {
+      mc.gotoAndStop(2);
+      if (Reflect.field(mc, "onFrutiRollOver") != null) mc.onFrutiRollOver();
+    }
+    mc.onRollOut = function() {
+      mc.gotoAndStop(1);
+      if (Reflect.field(mc, "onFrutiRollOut") != null) mc.onFrutiRollOut();
+    }
+    mc.onPress = function() {
+      mc.gotoAndStop(3);
+      if (Reflect.field(mc, "onFrutiPress") != null) mc.onFrutiPress();
+    }
+    mc.onRelease = function() {
+      mc.gotoAndStop(2);
+      if (Reflect.field(mc, "onFrutiRelease") != null) mc.onFrutiRelease();
+    }
+    if (Reflect.field(mc, "stop") != null) mc.stop();
+  }
+
+  public static function toString(mc:Dynamic, ?l:Int = 0):String {
+    if (Reflect.field(mc, "isRoot") == true) return "_root";
+    if (l > 10) return "..";
+
+    if (l == 0) {
+      return "[MovieClip: " + toString(mc._parent, l + 1) + "." + mc._name + "]";
+    }
+    return toString(mc._parent, l + 1) + "." + mc._name;
+  }
+}

--- a/packages/core-haxe/src/frutiparc/core/FEMCLoader.hx
+++ b/packages/core-haxe/src/frutiparc/core/FEMCLoader.hx
@@ -1,0 +1,58 @@
+package frutiparc.core;
+
+/**
+ * Portage Haxe du module AS2 FEMCLoader.
+ * Source legacy: frutiengine/FEMCLoader.as
+ */
+class FEMCLoader {
+  public static var urlList:Dynamic = {};
+
+  public var url:String;
+  public var wasFirst:Bool = false;
+  public var loadFn:Dynamic;
+  public var onCompleteHook:Dynamic;
+
+  public function new(?loadFn:Dynamic = null, ?onCompleteHook:Dynamic = null) {
+    this.loadFn = loadFn;
+    this.onCompleteHook = onCompleteHook;
+  }
+
+  public function loadClip(url:String, target:Dynamic, ?force:Bool = false):Dynamic {
+    if (force) return doLoad(url, target);
+
+    var o = Reflect.field(urlList, url);
+    if (o == null) {
+      this.wasFirst = true;
+      Reflect.setField(urlList, url, { loaded: false, objList: [] });
+      this.url = url;
+      return doLoad(url, target);
+    }
+
+    this.wasFirst = false;
+    if (Reflect.field(o, "loaded") == true) {
+      return doLoad(url, target);
+    }
+
+    var list:Array<Dynamic> = Reflect.field(o, "objList");
+    list.push({ obj: this, mc: target });
+    return null;
+  }
+
+  public function onLoadComplete(mc:Dynamic):Void {
+    if (this.wasFirst) {
+      var o = Reflect.field(urlList, this.url);
+      Reflect.setField(o, "loaded", true);
+      var list:Array<Dynamic> = Reflect.field(o, "objList");
+      for (i in 0...list.length) {
+        list[i].obj.loadClip(this.url, list[i].mc, true);
+      }
+      Reflect.setField(o, "objList", []);
+    }
+
+    if (onCompleteHook != null) onCompleteHook(mc);
+  }
+
+  function doLoad(url:String, target:Dynamic):Dynamic {
+    return loadFn != null ? loadFn(url, target) : null;
+  }
+}

--- a/packages/core-haxe/src/frutiparc/core/FENumber.hx
+++ b/packages/core-haxe/src/frutiparc/core/FENumber.hx
@@ -1,0 +1,73 @@
+package frutiparc.core;
+
+/**
+ * Portage Haxe (subset utile) du module AS2 FENumber.
+ * Source legacy: frutiengine/FENumber.as
+ */
+class FENumber {
+  public static function toColorObj(nb:Int):ColorObj {
+    return {
+      r: (nb >> 16) & 0xFF,
+      g: (nb >> 8) & 0xFF,
+      b: nb & 0xFF,
+    };
+  }
+
+  public static function toAlphaString(nb:Int):String {
+    if (nb > 26) {
+      var next:String;
+      if (nb % 26 == 0) {
+        next = toAlphaString(Std.int(Math.floor((nb - 1) / 26)));
+        nb = 26;
+      } else {
+        next = toAlphaString(Std.int(Math.floor(nb / 26)));
+        nb %= 26;
+      }
+      nb += 9;
+      return next + base36Char(nb);
+    }
+    return base36Char(nb + 9);
+  }
+
+  public static function encode62(n:Int, ?strlen:Int = 1):String {
+    var ret = "";
+    var value = n;
+    while (value > 0) {
+      var t = value % 62;
+      if (t < 36) ret = base36Char(t).toLowerCase() + ret;
+      else ret = base36Char(t - 26).toUpperCase() + ret;
+      value = Std.int((value - t) / 62);
+    }
+    while (strlen > ret.length) ret = "0" + ret;
+    return ret;
+  }
+
+  public static function toStringL(n:Dynamic, l:Int):String {
+    var value:Float = (n == null || Math.isNaN(n)) ? 0 : n;
+    var s = Std.string(Std.int(value));
+    while (s.length < l) s = "0" + s;
+    return s;
+  }
+
+  public static function modCol(nb:Int, ?inc:Float = 0, ?coef:Float = 1):Int {
+    var c = toColorObj(nb);
+    var r = clamp(Math.round((c.r + inc) * coef));
+    var g = clamp(Math.round((c.g + inc) * coef));
+    var b = clamp(Math.round((c.b + inc) * coef));
+    return (r << 16) + (g << 8) + b;
+  }
+
+  static function clamp(v:Int):Int {
+    return Std.int(Math.min(Math.max(0, v), 255));
+  }
+
+  static function base36Char(v:Int):String {
+    return "0123456789abcdefghijklmnopqrstuvwxyz".charAt(v);
+  }
+}
+
+typedef ColorObj = {
+  var r:Int;
+  var g:Int;
+  var b:Int;
+}

--- a/packages/core-haxe/src/frutiparc/core/FEObject.hx
+++ b/packages/core-haxe/src/frutiparc/core/FEObject.hx
@@ -1,0 +1,48 @@
+package frutiparc.core;
+
+/**
+ * Portage Haxe du module AS2 FEObject.
+ * Source legacy: frutiengine/FEObject.as
+ */
+class FEObject {
+  public static function clone(obj:Dynamic):Dynamic {
+    var r:Dynamic = {};
+    for (f in Reflect.fields(obj)) {
+      Reflect.setField(r, f, Reflect.field(obj, f));
+    }
+    return r;
+  }
+
+  public static function recursiveClone(obj:Dynamic):Dynamic {
+    var r:Dynamic = {};
+    for (f in Reflect.fields(obj)) {
+      var value = Reflect.field(obj, f);
+      if (Reflect.isObject(value) && value != null) {
+        Reflect.setField(r, f, recursiveClone(value));
+      } else {
+        Reflect.setField(r, f, value);
+      }
+    }
+    return r;
+  }
+
+  public static function addObject(obj:Dynamic, o:Dynamic, ?splash:Bool = false):Void {
+    for (element in Reflect.fields(o)) {
+      var current = Reflect.field(obj, element);
+      if (current == null || splash) {
+        Reflect.setField(obj, element, Reflect.field(o, element));
+      }
+    }
+  }
+
+  public static function toColNumber(obj:RGB):Int {
+    var str = "0x" + StringTools.hex(obj.r, 1).toLowerCase() + StringTools.hex(obj.g, 1).toLowerCase() + StringTools.hex(obj.b, 1).toLowerCase();
+    return Std.parseInt(str);
+  }
+}
+
+typedef RGB = {
+  var r:Int;
+  var g:Int;
+  var b:Int;
+}

--- a/packages/core-haxe/src/frutiparc/core/FEString.hx
+++ b/packages/core-haxe/src/frutiparc/core/FEString.hx
@@ -1,0 +1,114 @@
+package frutiparc.core;
+
+/**
+ * Portage Haxe (subset pragmatique) du module AS2 FEString.
+ * Source legacy: frutiengine/FEString.as
+ */
+class FEString {
+  public static function replace(str:String, search:String, repl:String):String {
+    if (search.length == 0) return str;
+    return str.split(search).join(repl);
+  }
+
+  public static function decode62(n:String):Float {
+    var r:Float = 0;
+    var coef:Float = 1;
+    for (i in 0...n.length) {
+      var c = n.substr(n.length - 1 - i, 1);
+      var t:Float;
+      if (c.toLowerCase() == c) {
+        t = parseInt(c, 36);
+      } else {
+        t = parseInt(c.toLowerCase(), 36) + 26;
+      }
+      r += t * coef;
+      coef *= 62;
+    }
+    return r;
+  }
+
+  public static function unHTML(r:String):String {
+    if (r.length <= 0) return r;
+    return replace(replace(replace(r, "&", "&amp;"), "<", "&lt;"), ">", "&gt;");
+  }
+
+  public static function rmChr(r:String, aChar:String):String {
+    if (r.length <= 0) return r;
+    return replace(r, aChar, "");
+  }
+
+  public static function ltrim(str:String):String {
+    var i = 0;
+    while (i < str.length && (str.substr(i, 1) == " " || str.substr(i, 1) == String.fromCharCode(13))) i++;
+    return str.substring(i);
+  }
+
+  public static function rtrim(str:String):String {
+    var i = str.length - 1;
+    while (i >= 0 && (str.substr(i, 1) == " " || str.substr(i, 1) == String.fromCharCode(13))) i--;
+    return str.substr(0, i + 1);
+  }
+
+  public static function trim(str:String):String {
+    return ltrim(rtrim(str));
+  }
+
+  public static function repeat(str:String, l:Int):String {
+    var r = "";
+    for (i in 0...l) r += str;
+    return r;
+  }
+
+  public static function countUpperCase(str:String):Int {
+    var count = 0;
+    for (i in 0...str.length) {
+      var t = str.substr(i, 1);
+      if (t != t.toLowerCase()) count++;
+    }
+    return count;
+  }
+
+  public static function startsWith(str1:String, str2:String):Bool {
+    return str1.substr(0, str2.length) == str2;
+  }
+
+  public static function endsWith(str1:String, str2:String):Bool {
+    return str1.substr(str1.length - str2.length) == str2;
+  }
+
+  public static function checkRepeat(str:String, max:Int):Bool {
+    if (str.length == 0) return false;
+    var last = str.charAt(0);
+    var nb = 1;
+    for (i in 1...str.length) {
+      var j = str.charAt(i);
+      if (j == last) nb++; else {
+        nb = 1;
+        last = j;
+      }
+      if (nb > max) return true;
+    }
+    return false;
+  }
+
+
+  public static function formatVars(str:String, obj:Dynamic):String {
+    var pos = str.indexOf("$");
+    while (pos > -1) {
+      var n = str.substr(pos + 1, 1);
+      if (n == "$") {
+        str = str.substr(0, pos) + "$" + str.substring(pos + 2, str.length);
+        pos = str.indexOf("$", pos + 2);
+      } else {
+        var r:Dynamic = Reflect.field(obj, n);
+        str = str.substr(0, pos) + Std.string(r) + str.substring(pos + 2, str.length);
+        pos = str.indexOf("$", pos + Std.string(r).length);
+      }
+    }
+    return str;
+  }
+
+  public static function replaceBackSlashN(r:String):String {
+    return replace(r, "\\n", "\n");
+  }
+}

--- a/packages/core-haxe/src/frutiparc/core/FFileMng.hx
+++ b/packages/core-haxe/src/frutiparc/core/FFileMng.hx
@@ -1,0 +1,106 @@
+package frutiparc.core;
+
+/**
+ * Portage Haxe du module AS2 FFileMng.
+ * Source legacy: frutiengine/FFileMng.as
+ */
+class FFileMng {
+  public var tree:Dynamic;
+  public var messages:String = "";
+  public var inbox:String = "";
+  public var blackbox:String = "";
+  public var draftbox:String = "";
+  public var outbox:String = "";
+  public var disccollector:String = "";
+  public var inventory:String = "";
+  public var mycontact:String = "";
+  public var recyclebin:String = "";
+
+  public function new() {
+    this.tree = {};
+  }
+
+  public function onLoadTree(success:Bool, data:Dynamic):Bool {
+    if (!success) return false;
+
+    var bFolder = Std.string(data.lastChild.attributes.b).split(";");
+    this.messages = bFolder[0];
+    this.inbox = bFolder[1];
+    this.outbox = bFolder[2];
+    this.blackbox = bFolder[3];
+    this.draftbox = bFolder[4];
+    this.disccollector = bFolder[5];
+    this.inventory = bFolder[6];
+    this.mycontact = bFolder[7];
+    this.recyclebin = bFolder[8];
+
+    return this.analyseTree(data.lastChild, null);
+  }
+
+  public function analyseTree(node:Dynamic, parent:Dynamic):Bool {
+    var cur = node;
+    while (cur != null && cur.nodeType > 0) {
+      if (cur.nodeName == "f" || cur.nodeName == "s") {
+        if (cur.attributes.u == null) cur.attributes.u = "root";
+
+        Reflect.setField(this.tree, cur.attributes.u, {
+          name: cur.attributes.n,
+          type: cur.attributes.t,
+          tpl: cur.attributes.p,
+          childs: [],
+          parent: parent,
+        });
+
+        if (parent != null && cur.nodeName == "f") {
+          var p:Dynamic = Reflect.field(this.tree, parent);
+          cast(p.childs, Array<Dynamic>).push(cur.attributes.u);
+        }
+
+        if (cur.hasChildNodes != null && cur.hasChildNodes()) {
+          this.analyseTree(cur.firstChild, cur.attributes.u);
+        }
+      }
+      cur = cur.nextSibling;
+    }
+    return true;
+  }
+
+  public function analyseXml(d:Dynamic):Dynamic {
+    var infos:Dynamic = Reflect.field(this.tree, d.attributes.u);
+    if (infos == null) return null;
+
+    var l:Dynamic = {
+      uid: d.attributes.u,
+      type: "folder",
+      desc: [infos.name, infos.type],
+      tpl: infos.tpl,
+      parent: infos.parent,
+      list: [],
+    };
+
+    var n = d.firstChild;
+    while (n != null && n.nodeType > 0) {
+      if (this.isFileValid(n)) {
+        if (n.nodeName == "e") {
+          l.list.push({
+            uid: n.attributes.u,
+            type: n.attributes.t,
+            size: n.attributes.s,
+            date: n.attributes.d,
+            access: n.attributes.a,
+            desc: Std.string(n.firstChild.nodeValue).split("\r\n"),
+            parent: d.attributes.u,
+          });
+        } else if (n.nodeName == "f") {
+          l.list.push(analyseXml(n));
+        }
+      }
+      n = n.nextSibling;
+    }
+    return l;
+  }
+
+  public function isFileValid(node:Dynamic):Bool {
+    return true;
+  }
+}

--- a/packages/core-haxe/src/frutiparc/core/FileLoader.hx
+++ b/packages/core-haxe/src/frutiparc/core/FileLoader.hx
@@ -1,0 +1,85 @@
+package frutiparc.core;
+
+/**
+ * Portage Haxe (noyau état/événements) du module AS2 FileLoader.
+ * Source legacy: frutiengine/FileLoader.as
+ */
+class FileLoader {
+  public var url:String;
+  public var size:Null<Float>;
+  public var mc:Dynamic;
+  public var loaded:Bool = false;
+  public var bytesTotal:Float = 0;
+  public var bytesLoaded:Float = 0;
+  public var bytesToLoad:Float = 0;
+  public var percent:Float = 0;
+  public var timeStart:Float = 0;
+  public var timeElapsed:Float = 0;
+  public var estimatedTimeLeft:Float = 0;
+  public var transferRate:Float = 0;
+  public var loader:Dynamic;
+
+  var listeners:Array<Dynamic> = [];
+
+  public function new(url:String, ?size:Null<Float> = null, ?loader:Dynamic = null) {
+    this.url = url;
+    this.size = size;
+    this.loader = loader;
+  }
+
+  public function addListener(listener:Dynamic):Void listeners.push(listener);
+  public function removeListener(listener:Dynamic):Void listeners = listeners.filter(function(l) return l != listener);
+
+  public function loadClip(mc:Dynamic, ?now:Float = -1):Void {
+    this.mc = mc;
+    this.timeStart = now >= 0 ? now : Date.now().getTime();
+    if (loader != null) loader.loadClip(this.url, this.mc, this);
+  }
+
+  public function onLoadError(a:Dynamic, b:Dynamic):Void {
+    this.loaded = false;
+    broadcastMessage("onFileNotFoundError", [a, b]);
+  }
+
+  public function onLoadStart():Void broadcastMessage("onLoadStart", []);
+
+  public function onLoadProgress(mc:Dynamic, loadedBytes:Float, totalBytes:Float, ?now:Float = -1):Void {
+    this.bytesLoaded = loadedBytes;
+    this.bytesTotal = totalBytes;
+    this.bytesToLoad = this.bytesTotal - this.bytesLoaded;
+    this.percent = this.bytesTotal == 0 ? 0 : Math.round(this.bytesLoaded * 10000 / this.bytesTotal) / 100;
+
+    var current = now >= 0 ? now : Date.now().getTime();
+    this.timeElapsed = current - this.timeStart;
+    this.transferRate = this.timeElapsed <= 0 ? 0 : this.bytesLoaded / this.timeElapsed;
+    this.estimatedTimeLeft = this.transferRate <= 0 ? 0 : this.bytesToLoad / this.transferRate;
+
+    broadcastMessage("onLoadProgress", [mc, loadedBytes, totalBytes]);
+  }
+
+  public function onLoadComplete(?progress:Dynamic = null):Void {
+    if (progress != null) {
+      this.bytesLoaded = progress.bytesLoaded;
+      this.bytesTotal = progress.bytesTotal;
+    }
+
+    if (this.size == null || this.size == this.bytesLoaded) {
+      this.loaded = true;
+      broadcastMessage("onLoadComplete", []);
+    } else {
+      broadcastMessage("onFalseSizeError", []);
+    }
+  }
+
+  public function onLoadInit():Void {
+    if (this.size == null || this.size == this.bytesLoaded) broadcastMessage("onLoadInit", []);
+    else broadcastMessage("onFalseSizeError", []);
+  }
+
+  function broadcastMessage(method:String, args:Array<Dynamic>):Void {
+    for (l in listeners) {
+      var fn = Reflect.field(l, method);
+      if (fn != null) Reflect.callMethod(l, fn, args);
+    }
+  }
+}

--- a/packages/core-haxe/src/frutiparc/core/HTTP.hx
+++ b/packages/core-haxe/src/frutiparc/core/HTTP.hx
@@ -1,0 +1,69 @@
+package frutiparc.core;
+
+/**
+ * Portage Haxe (noyau orchestration) du module AS2 HTTP.
+ * Source legacy: frutiengine/HTTP.as
+ *
+ * Cette version conserve surtout la logique de file (queue) et de callback,
+ * en déléguant l'I/O à une fonction `transport` injectable.
+ */
+class HTTP {
+  public static var queue:Array<HTTP> = [];
+  public static var flIdle:Bool = true;
+  public static var defaultParams:Dynamic = {};
+  public static var defaultHeaders:Dynamic = {};
+
+  public var action:String;
+  public var params:Dynamic;
+  public var callback:Dynamic;
+  public var method:String;
+  public var extra:Dynamic;
+  public var output:Dynamic;
+  public var transport:Dynamic;
+
+  public function new(action:String, params:Dynamic, callback:Dynamic, ?method:String = "GET", ?extra:Dynamic = null, ?transport:Dynamic = null) {
+    this.action = action;
+    this.params = params;
+    this.callback = callback;
+    this.method = method;
+    this.extra = extra;
+    this.transport = transport;
+
+    this.output = FEObject.clone(defaultParams);
+    FEObject.addObject(this.output, params, true);
+
+    submitMe(this);
+  }
+
+  public static function submitMe(obj:HTTP):Void {
+    if (flIdle) {
+      flIdle = false;
+      obj.submit();
+    } else {
+      queue.push(obj);
+    }
+  }
+
+  public static function goNext():Void {
+    if (queue.length == 0) {
+      flIdle = true;
+    } else {
+      var t = queue.shift();
+      t.submit();
+    }
+  }
+
+  function submit():Void {
+    if (transport == null) {
+      callback.obj[callback.method](false, null, extra);
+      HTTP.goNext();
+      return;
+    }
+
+    var self = this;
+    transport(action, output, method, function(success:Bool, data:Dynamic) {
+      self.callback.obj[self.callback.method](success, data, self.extra);
+      HTTP.goNext();
+    });
+  }
+}

--- a/packages/core-haxe/src/frutiparc/core/Lang.hx
+++ b/packages/core-haxe/src/frutiparc/core/Lang.hx
@@ -1,0 +1,95 @@
+package frutiparc.core;
+
+/**
+ * Portage Haxe (noyau métier) du module AS2 Lang.
+ * Source legacy: frutiengine/Lang.as
+ */
+class Lang {
+  public static var varName = "langText";
+
+  public static function fv(path:String, obj:Dynamic, langText:Dynamic):String {
+    var base:Dynamic = dig(langText, path);
+    return base != null ? FEString.formatVars(Std.string(base), obj) : "[ERR] " + path;
+  }
+
+  public static function formatDateObject(obj:Dynamic, format:String, langText:Dynamic):String {
+    Reflect.setField(obj, "A", dig(langText, "date.day_short." + Reflect.field(obj, "b")));
+    Reflect.setField(obj, "a", dig(langText, "date.day." + Reflect.field(obj, "b")));
+    Reflect.setField(obj, "M", dig(langText, "date.month_short." + Reflect.field(obj, "n")));
+    Reflect.setField(obj, "m", dig(langText, "date.month." + Reflect.field(obj, "n")));
+
+    var base:Dynamic = (format != null) ? dig(langText, "date.format_" + format) : null;
+    return base != null ? FEString.formatVars(Std.string(base), obj) : FEString.formatVars("$Y-$N-$D $H:$I:$S", obj);
+  }
+
+  public static function formatDate(date:Date, format:String, langText:Dynamic):String {
+    return formatDateObject(FEDate.getCompleteObject(date), format, langText);
+  }
+
+  public static function formatDateString(date:String, format:String, langText:Dynamic):String {
+    return formatDate(FEDate.newFromString(date), format, langText);
+  }
+
+  public static function formatDateTime(t:Float, format:String, langText:Dynamic):String {
+    return formatDate(FEDate.newFromTime(t), format, langText);
+  }
+
+  public static function formatDuration(dur:Float, format:String, langText:Dynamic):String {
+    var d = Math.round(dur);
+    var obj:Dynamic = {
+      m: d % 1000,
+      s: Math.floor(d / 1000) % 60,
+      i: Math.floor(d / 60000) % 60,
+      h: Math.floor(d / 3600000),
+    };
+    var f = format == null ? "default" : format;
+    if (obj.h > 0) return FEString.formatVars(dig(langText, "duration.format_" + f + ".h"), obj);
+    if (obj.i > 0) return FEString.formatVars(dig(langText, "duration.format_" + f + ".i"), obj);
+    if (obj.s > 0) return FEString.formatVars(dig(langText, "duration.format_" + f + ".s"), obj);
+    return FEString.formatVars(dig(langText, "duration.format_" + f + ".m"), obj);
+  }
+
+  public static function card2ord(p:Int, langText:Dynamic):String {
+    var key = switch (p) {
+      case 1: "first";
+      case 2: "second";
+      case 3: "third";
+      case 4: "fourth";
+      case 5: "fifth";
+      default: "def";
+    }
+    return Std.string(p) + Std.string(dig(langText, "ordinal." + key));
+  }
+
+  public static function country(co:String, langText:Dynamic):String {
+    var r = dig(langText, "countries." + co + ".name");
+    return r == null ? "Inconnu" : Std.string(r);
+  }
+
+  public static function region(co:String, rg:String, langText:Dynamic):String {
+    var r = dig(langText, "countries." + co + ".region." + rg);
+    return r == null ? "Inconnu" : Std.string(r);
+  }
+
+  public static function sign(fs:Int, langText:Dynamic):Dynamic {
+    return dig(langText, "sign." + fs);
+  }
+
+  public static function gameName(discName:String, langText:Dynamic):String {
+    var r = dig(langText, "disc_to_game." + discName);
+    return r == null ? discName : Std.string(r);
+  }
+
+  public static function getTipDoc(id:String, langText:Dynamic):Dynamic {
+    return dig(langText, "tip_doc." + id);
+  }
+
+  static function dig(obj:Dynamic, path:String):Dynamic {
+    var cur:Dynamic = obj;
+    for (part in path.split(".")) {
+      if (cur == null) return null;
+      cur = Reflect.field(cur, part);
+    }
+    return cur;
+  }
+}

--- a/packages/core-haxe/src/frutiparc/core/MD5.hx
+++ b/packages/core-haxe/src/frutiparc/core/MD5.hx
@@ -1,0 +1,13 @@
+package frutiparc.core;
+
+import haxe.crypto.Md5;
+
+/**
+ * Portage Haxe du module AS2 MD5.
+ * Source legacy: frutiengine/MD5.as
+ */
+class MD5 {
+  public static function encode(str:String):String {
+    return Md5.encode(str);
+  }
+}

--- a/packages/core-haxe/src/frutiparc/core/Pref.hx
+++ b/packages/core-haxe/src/frutiparc/core/Pref.hx
@@ -1,0 +1,111 @@
+package frutiparc.core;
+
+/**
+ * Portage Haxe (noyau métier) du module AS2 Pref.
+ * Source legacy: frutiengine/Pref.as
+ */
+class Pref {
+  public var types:Dynamic;
+  public var prefs:Dynamic;
+  public var prefsId:Array<String>;
+
+  public function new() {
+    this.types = { b: "bool", i: "int", s: "string" };
+    this.prefs = {};
+    this.prefsId = [];
+  }
+
+  public function onLoadPrefDef(success:Bool, data:Dynamic):Void {
+    if (!success) return;
+    var str:String = Reflect.field(data, "PrefDef");
+    while (str.length > 0) {
+      var id = Std.int(FEString.decode62(str.substr(0, 2)));
+      str = str.substr(2);
+
+      var t:String = Reflect.field(types, str.substr(0, 1));
+      str = str.substr(1);
+
+      var l1 = Std.int(FEString.decode62(str.substr(0, 2)));
+      var name = str.substr(2, l1);
+      str = str.substr(l1 + 2);
+
+      var l2 = Std.int(FEString.decode62(str.substr(0, 2)));
+      var defaultValue:Dynamic = str.substr(2, l2);
+      str = str.substr(l2 + 2);
+
+      defaultValue = convert(defaultValue, t);
+      var entry:Dynamic = { type: t, default_value: defaultValue, value: defaultValue, id: id };
+      Reflect.setField(this.prefs, name, entry);
+      this.prefsId[id] = name;
+    }
+  }
+
+  public function useMyPref(str:String):Void {
+    while (str.length > 0) {
+      var id = Std.int(FEString.decode62(str.substr(0, 2)));
+      var l = Std.int(FEString.decode62(str.substr(2, 2)));
+      var value:Dynamic = str.substr(4, l);
+      str = str.substr(l + 4);
+
+      var name = this.prefsId[id];
+      var pref = Reflect.field(this.prefs, name);
+      var t = Reflect.field(pref, "type");
+      value = convert(value, t);
+      if (value != null) Reflect.setField(pref, "value", value);
+    }
+  }
+
+  public function getFormatedPref():String {
+    var r = "";
+    for (n in Reflect.fields(this.prefs)) {
+      var o:Dynamic = Reflect.field(this.prefs, n);
+      if (Reflect.field(o, "value") != Reflect.field(o, "default_value")) {
+        var content:String;
+        switch (Reflect.field(o, "type")) {
+          case "bool":
+            content = Reflect.field(o, "value") ? "Y" : "N";
+          case "int":
+            content = FENumber.encode62(Std.int(Reflect.field(o, "value")));
+          default:
+            content = Std.string(Reflect.field(o, "value"));
+        }
+        r += FENumber.encode62(Std.int(Reflect.field(o, "id")), 2);
+        r += FENumber.encode62(content.length, 2) + content;
+      }
+    }
+    return r;
+  }
+
+  public function getPref(n:String):Dynamic {
+    var pref = Reflect.field(this.prefs, n);
+    if (n == "cache_length" && Reflect.field(pref, "value") == null) return 30;
+    return Reflect.field(pref, "value");
+  }
+
+  public function setPref(n:String, v:Dynamic):Void {
+    var pref = Reflect.field(this.prefs, n);
+    Reflect.setField(pref, "value", v);
+  }
+
+  public function setFromCopy(nPrefs:Dynamic):Void {
+    for (n in Reflect.fields(nPrefs)) {
+      var u = Reflect.field(nPrefs, n);
+      var o = Reflect.field(this.prefs, Reflect.field(u, "name"));
+      if (o == null) continue;
+      Reflect.setField(o, "value", Reflect.field(u, "value"));
+    }
+  }
+
+  public function getACopy():Dynamic {
+    return FEObject.recursiveClone(this.prefs);
+  }
+
+  public function convert(value:Dynamic, t:String):Dynamic {
+    if (t == "int") {
+      var v = FEString.decode62(Std.string(value));
+      return Math.isNaN(v) ? null : v;
+    }
+    if (t == "bool") return Std.string(value) == "Y";
+    return value;
+  }
+}

--- a/packages/core-haxe/src/frutiparc/core/RunDate.hx
+++ b/packages/core-haxe/src/frutiparc/core/RunDate.hx
@@ -1,0 +1,59 @@
+package frutiparc.core;
+
+/**
+ * Portage Haxe du module AS2 RunDate.
+ * Source legacy: frutiengine/RunDate.as
+ */
+class RunDate {
+  public var ref:Date;
+  public var refLocal:Date;
+  public var diff:Float;
+
+  public function new() {
+    this.diff = 0;
+  }
+
+  public function setFromString(str:String):Void {
+    this.refLocal = Date.now();
+    this.ref = FEDate.newFromString(str);
+    this.diff = this.ref.getTime() - this.refLocal.getTime();
+  }
+
+  public function getTime():Float {
+    var d = Date.now();
+    if (this.ref != null) return d.getTime() + this.diff;
+    return d.getTime();
+  }
+
+  public function getDateObject():Date {
+    var d = Date.now();
+    if (this.ref != null) d = Date.fromTime(d.getTime() + this.diff);
+    return d;
+  }
+
+  public function getObject():Dynamic {
+    return FEDate.getObject(getDateObject());
+  }
+
+  public function getCompleteObject():Dynamic {
+    return FEDate.getCompleteObject(getDateObject());
+  }
+
+  public function toString():String {
+    return getDateObject().toString();
+  }
+
+  public function toFormat(format:String, formatter:Dynamic->String->String):String {
+    return formatter(this.getCompleteObject(), format);
+  }
+
+  public function getCurrentFSign():Dynamic {
+    var t = this.getTime() / 1000;
+    return {
+      sign: Math.floor(((t - 345600) / 604800) % 10),
+      signb: Math.floor((t / 3600) % 10),
+      signCompletion: ((t - 345600) / 604800) % 1,
+      signbCompletion: (t / 3600) % 1,
+    };
+  }
+}

--- a/packages/core-haxe/src/frutiparc/core/Slot.hx
+++ b/packages/core-haxe/src/frutiparc/core/Slot.hx
@@ -1,0 +1,173 @@
+package frutiparc.core;
+
+/**
+ * Portage Haxe (noyau métier) du module AS2 Slot.
+ * Source legacy: frutiengine/Slot.as
+ */
+class Slot {
+  public static var depths:Dynamic = {
+    boxList: {
+      start: 0,
+      dst: 1,
+      max: 100,
+    }
+  };
+
+  public var slotList:Dynamic;
+  public var arr:Array<Dynamic>;
+  public var nbBox:Int;
+  public var flActive:Bool;
+  public var baseDepth:Int;
+  public var depth:Int;
+  public var activeBox:Dynamic;
+  public var title:String;
+  public var flWarning:Bool;
+  public var flDesktopable:Bool;
+  public var flClose:Bool;
+
+  public function new() {
+    this.nbBox = 0;
+    this.flActive = false;
+    this.flWarning = false;
+    this.depth = -1;
+    this.activeBox = null;
+    this.flDesktopable = false;
+    this.flClose = false;
+    this.arr = [];
+    this.baseDepth = 0;
+  }
+
+  public function init(slotList:Dynamic, baseDepth:Int, ?flGo:Bool = false):Void {
+    this.arr = [];
+    this.slotList = slotList;
+    this.baseDepth = baseDepth;
+
+    if (flGo) this.slotList.activate(this);
+  }
+
+  public function setDepth(baseDepth:Int):Void {
+    this.baseDepth = baseDepth;
+    this.cleanDepths();
+  }
+
+  public function addBox(box:Dynamic):Void {
+    var d = this.getNextDepth();
+    this.arr[d] = box;
+    this.nbBox++;
+    box.init(this, this.baseDepth + depths.boxList.start + depths.boxList.dst * d);
+    this.activate(box);
+    this.onBoxListChanged();
+  }
+
+  public function rmBox(box:Dynamic):Void {
+    var id = this.arr.indexOf(box);
+    if (id > -1) {
+      this.arr[id] = null;
+      this.nbBox--;
+      this.onBoxListChanged();
+    }
+  }
+
+  public function getNextDepth():Int {
+    if (this.depth + 1 > (depths.boxList.max - depths.boxList.start)) {
+      this.cleanDepths();
+    }
+    this.depth++;
+    return this.depth;
+  }
+
+  public function cleanDepths():Void {
+    var i = 0;
+    while (i < this.arr.length) {
+      if (this.arr[i] == null) {
+        this.arr.splice(i, 1);
+      } else {
+        this.arr[i].setDepth(this.baseDepth + depths.boxList.start + depths.boxList.dst * i);
+        i++;
+      }
+    }
+  }
+
+  public function putOnTop(box:Dynamic):Void {
+    var id = this.arr.indexOf(box);
+    if (id > -1) {
+      this.arr[id] = null;
+      var d = this.getNextDepth();
+      this.arr[d] = box;
+      box.setDepth(this.baseDepth + depths.boxList.start + depths.boxList.dst * d);
+    }
+  }
+
+  public function onBoxListChanged():Void {}
+
+  public function close():Void {
+    this.flClose = true;
+    this.slotList.rmSlot(this);
+  }
+
+  public function tryToClose():Void {
+    if (this.arr.length == 0) {
+      this.close();
+    } else {
+      for (i in 0...this.arr.length) {
+        if (this.arr[i] != null) this.arr[i].tryToClose();
+      }
+    }
+  }
+
+  public function onActivate():Void {
+    this.flActive = true;
+
+    if (this.flWarning) this.onStopWarning();
+
+    for (i in 0...this.arr.length) if (this.arr[i] != null) this.arr[i].onSlotActivate();
+  }
+
+  public function onDeactivate():Void {
+    this.flActive = false;
+    for (i in 0...this.arr.length) if (this.arr[i] != null) this.arr[i].onSlotDeactivate();
+  }
+
+  public function activate(box:Dynamic):Bool {
+    if (this.activeBox == box) return false;
+    if (this.activeBox != null) this.activeBox.onDeactivate();
+
+    this.activeBox = box;
+    this.putOnTop(box);
+    this.activeBox.onActivate();
+    return true;
+  }
+
+  public function move(box:Dynamic, newSlot:Dynamic):Void {
+    this.rmBox(box);
+    newSlot.addBox(box);
+  }
+
+  public function setTitle(t:String):Void {
+    this.title = t;
+  }
+
+  public function warning():Bool {
+    if (this.flActive) return false;
+    if (this.flWarning) return false;
+
+    this.onWarning();
+    return true;
+  }
+
+  public function onWarning():Bool {
+    if (this.flWarning) return false;
+
+    this.flWarning = true;
+    return true;
+  }
+
+  public function onStopWarning():Bool {
+    if (!this.flWarning) return false;
+
+    this.flWarning = false;
+    return true;
+  }
+
+  public function onStageResize():Void {}
+}

--- a/packages/core-haxe/src/frutiparc/core/SlotBase.hx
+++ b/packages/core-haxe/src/frutiparc/core/SlotBase.hx
@@ -1,0 +1,19 @@
+package frutiparc.core;
+
+/**
+ * Base de transition pour remplacer temporairement la dépendance AS2 `Slot`.
+ * Permet de préserver la signature `init(slotList, depth, flGo)` utilisée par Desktop.
+ */
+class SlotBase {
+  public var lastInitSlotList:Dynamic = null;
+  public var lastInitDepth:Dynamic = null;
+  public var lastInitFlGo:Dynamic = null;
+
+  public function new() {}
+
+  public function init(slotList:Dynamic, depth:Dynamic, flGo:Dynamic):Void {
+    this.lastInitSlotList = slotList;
+    this.lastInitDepth = depth;
+    this.lastInitFlGo = flGo;
+  }
+}

--- a/packages/core-haxe/src/frutiparc/core/SlotList.hx
+++ b/packages/core-haxe/src/frutiparc/core/SlotList.hx
@@ -1,0 +1,83 @@
+package frutiparc.core;
+
+/**
+ * Portage Haxe (noyau métier) du module AS2 SlotList.
+ * Source legacy: frutiengine/SlotList.as
+ */
+class SlotList {
+  public static var depths:Dynamic = {
+    slotList: {
+      start: 0,
+      dst: 1,
+      max: 50,
+    }
+  };
+
+  public var arr:Array<Dynamic>;
+  public var depth:Int = -1;
+  public var activeSlot:Dynamic = null;
+
+  public function new() {}
+
+  public function init():Void {
+    this.arr = [];
+  }
+
+  public function addSlot(slot:Dynamic, ?flGo:Bool = false):Void {
+    var d = this.getNextDepth();
+    this.arr[d] = slot;
+    slot.init(this, depths.slotList.start + depths.slotList.dst * d, flGo);
+  }
+
+  public function rmSlot(slot:Dynamic):Bool {
+    var id = this.arr.indexOf(slot);
+    if (id > -1) {
+      this.arr[id] = null;
+      if (this.activeSlot == slot) this.activeSlot = null;
+      return true;
+    }
+    return false;
+  }
+
+  public function getNextDepth():Int {
+    if (this.depth + 1 > (depths.slotList.max - depths.slotList.start)) {
+      this.cleanDepths();
+    }
+    this.depth++;
+    return this.depth;
+  }
+
+  public function cleanDepths():Void {
+    var i = 0;
+    while (i < arr.length) {
+      if (arr[i] == null) {
+        arr.splice(i, 1);
+      } else {
+        arr[i].setDepth(depths.slotList.start + depths.slotList.dst * i);
+        i++;
+      }
+    }
+  }
+
+  public function putOnTop(slot:Dynamic):Void {
+    var id = this.arr.indexOf(slot);
+    if (id > -1) {
+      this.arr[id] = null;
+      var d = this.getNextDepth();
+      this.arr[d] = slot;
+      slot.setDepth(depths.slotList.start + depths.slotList.dst * d);
+    }
+  }
+
+  public function activate(slot:Dynamic):Bool {
+    if (slot == null) return false;
+    if (this.activeSlot == slot) return false;
+    if (slot.flClose == true) return false;
+
+    if (this.activeSlot != null) this.activeSlot.onDeactivate();
+
+    this.activeSlot = slot;
+    this.activeSlot.onActivate();
+    return true;
+  }
+}

--- a/packages/core-haxe/src/frutiparc/core/StatusMng.hx
+++ b/packages/core-haxe/src/frutiparc/core/StatusMng.hx
@@ -1,0 +1,82 @@
+package frutiparc.core;
+
+/**
+ * Portage Haxe (noyau métier) du module AS2 StatusMng.
+ * Source legacy: frutiengine/StatusMng.as
+ */
+class StatusMng {
+  public static var externalList:Array<Dynamic> = [null, "eat", "work", "zzz", "phone", "away"];
+  public static var internalList:Array<Dynamic> = [null, "forum", "bkiwi", "mb2", "swapou2", "snake3", "bandas", "grapiz", "kaluga", "miniwave"];
+
+  public static function analyseStr(str:String):Dynamic {
+    var iExt = FEString.decode62(str.substr(0, 1));
+    if (Math.isNaN(iExt)) iExt = 0;
+
+    var iInt = FEString.decode62(str.substr(1, 2));
+    if (Math.isNaN(iInt)) iInt = 0;
+
+    var iEmote = FEString.decode62(str.substr(3, 1));
+    if (Math.isNaN(iEmote)) iEmote = 0;
+
+    return {
+      external: externalList[Std.int(iExt)],
+      internal: internalList[Std.int(iInt)],
+      emote: Std.int(iEmote),
+    };
+  }
+
+  public var external:Int = 0;
+  public var internal:Int = 0;
+  public var emote:Int = 0;
+  public var cnx:Dynamic;
+  public var last:String;
+
+  public function new() {}
+
+  public function setExternal(name:String):Void {
+    this.external = 0;
+    for (i in 0...externalList.length) {
+      if (externalList[i] == name) {
+        this.external = i;
+        break;
+      }
+    }
+    send();
+  }
+
+  public function setInternal(name:String):Void {
+    var idx = internalList.indexOf(name);
+    this.internal = idx < 0 ? 0 : idx;
+    send();
+  }
+
+  public function unsetInternal(name:String):Void {
+    var idx = internalList.indexOf(name);
+    if (this.internal == idx) {
+      this.internal = 0;
+      send();
+    }
+  }
+
+  public function setEmote(eId:Dynamic):Void {
+    var parsed = Std.parseInt(Std.string(eId));
+    if (parsed == null) return;
+
+    this.emote = parsed;
+    send();
+  }
+
+  public function setCnx(cnx:Dynamic):Void {
+    this.cnx = cnx;
+  }
+
+  public function send():Bool {
+    var str = FENumber.encode62(this.external, 1) + FENumber.encode62(this.internal, 2) + FENumber.encode62(this.emote, 0);
+    if (str == this.last) return false;
+    if (this.cnx != null && Reflect.field(this.cnx, "cmd") != null) {
+      this.cnx.cmd("status", {s: str});
+    }
+    this.last = str;
+    return true;
+  }
+}

--- a/packages/core-haxe/src/frutiparc/core/Tab.hx
+++ b/packages/core-haxe/src/frutiparc/core/Tab.hx
@@ -1,0 +1,29 @@
+package frutiparc.core;
+
+/**
+ * Portage Haxe du module AS2 Tab.
+ * Source legacy: frutiengine/Tab.as
+ */
+class Tab extends Slot {
+  public function new() {
+    super();
+  }
+
+  override public function init(slotList:Dynamic, baseDepth:Int, ?flGo:Bool = false):Void {
+    super.init(slotList, baseDepth, flGo);
+  }
+
+  public function addTabBox(box:Dynamic):Bool {
+    if (this.nbBox == 0) {
+      super.addBox(box);
+      return true;
+    }
+    return false;
+  }
+
+  override public function rmBox(box:Dynamic):Void {
+    super.rmBox(box);
+    this.cleanDepths();
+    if (this.nbBox == 0) this.close();
+  }
+}

--- a/packages/core-haxe/src/frutiparc/core/UserListMng.hx
+++ b/packages/core-haxe/src/frutiparc/core/UserListMng.hx
@@ -1,0 +1,165 @@
+package frutiparc.core;
+
+/**
+ * Portage Haxe (noyau métier) du module AS2 UserListMng.
+ * Source legacy: frutiengine/UserListMng.as
+ */
+class UserListMng {
+  public var list:Map<String, UserMng>;
+  public var arr:Array<UserMng>;
+  public var length:Int;
+  public var listenerList:Array<Dynamic>;
+  public var userMngClass:Dynamic;
+
+  public function new(?userMngClass:Dynamic = null) {
+    this.list = new Map();
+    this.arr = [];
+    this.listenerList = [];
+    this.length = 0;
+    this.userMngClass = userMngClass == null ? UserMng : userMngClass;
+  }
+
+  public function addUser(u:Dynamic, ?infoBasic:Dynamic = null, ?flMode:Bool = false, ?callOnChange:Bool = true):Void {
+    var key = Std.string(u);
+    if (!list.exists(key)) {
+      length++;
+      var user:UserMng = Type.createInstance(userMngClass, [key, infoBasic, flMode]);
+      list.set(key, user);
+      arr.push(user);
+    }
+    if (callOnChange) onChange();
+  }
+
+  public function rmUser(u:Dynamic, ?callOnChange:Bool = true):Bool {
+    var key = Std.string(u);
+    var user = list.get(key);
+    var removed = false;
+
+    if (user != null) {
+      var idx = arr.indexOf(user);
+      if (idx >= 0) {
+        arr.splice(idx, 1);
+        removed = true;
+      }
+      length--;
+      user.onDelete();
+      list.remove(key);
+    }
+
+    if (callOnChange) onChange();
+    return removed;
+  }
+
+  public function rmAll():Void {
+    for (user in arr) user.onDelete();
+    list = new Map();
+    arr = [];
+    length = 0;
+  }
+
+  public function defineMc(u:Dynamic, mc:Dynamic):Void {
+    var key = Std.string(u);
+    if (key.length == 0) return;
+    var user = list.get(key);
+    if (user != null) user.setMc(mc);
+  }
+
+  public function undefineMc(u:Dynamic, mc:Dynamic):Void {
+    var key = Std.string(u);
+    if (key.length == 0) return;
+    var user = list.get(key);
+    if (user != null) user.unsetMc(mc);
+  }
+
+  public function onChange():Void {
+    arr.sort(function(a, b) return Reflect.compare(a.sortString, b.sortString));
+    sendToAllListeners();
+  }
+
+  public function onUserAction(u:Dynamic, act:Dynamic):Void {
+    var key = Std.string(u);
+    if (key.length == 0) return;
+    var user = list.get(key);
+    if (user != null) user.onAction(act);
+  }
+
+  public function wantList(obj:Dynamic, method:String, start:Int, length:Int):Void {
+    var listener = getListenerByObj(obj);
+    if (listener == null) {
+      listener = {obj: obj, method: method, length: length, start: start};
+      listenerList.push(listener);
+    } else {
+      listener.method = method;
+      listener.length = length;
+      listener.start = start;
+    }
+
+    sendToListener(listener);
+  }
+
+  public function noMoreList(obj:Dynamic):Bool {
+    for (i in 0...listenerList.length) {
+      if (Reflect.field(listenerList[i], "obj") == obj) {
+        listenerList.splice(i, 1);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public function sendToAllListeners():Void {
+    for (listener in listenerList) sendToListener(listener);
+  }
+
+  public function sendToListener(listener:Dynamic):Void {
+    var start:Int = Reflect.field(listener, "start");
+    var count:Int = Reflect.field(listener, "length");
+    var method:String = Reflect.field(listener, "method");
+    var obj:Dynamic = Reflect.field(listener, "obj");
+    var users = getPartAttrib(start, count, "u");
+    Reflect.callMethod(obj, Reflect.field(obj, method), [users, this.length]);
+  }
+
+  public function isInList(user:String):Bool {
+    return list.exists(Std.string(user));
+  }
+
+  public function getRealUserName(user:String):String {
+    var asked = Std.string(user);
+    var askedLower = asked.toLowerCase();
+    for (u in arr) {
+      if (u.u.toLowerCase() == askedLower) return u.u;
+    }
+    return asked;
+  }
+
+  public function modePresent():Bool {
+    for (u in arr) if (u.flMode) return true;
+    return false;
+  }
+
+  public function isMode(user:String):Bool {
+    var u = list.get(Std.string(user));
+    return u != null && u.flMode;
+  }
+
+  public function getUserArray():Array<String> {
+    return getPartAttrib(0, this.length, "u");
+  }
+
+  function getListenerByObj(obj:Dynamic):Dynamic {
+    for (listener in listenerList) if (Reflect.field(listener, "obj") == obj) return listener;
+    return null;
+  }
+
+  function getPartAttrib(start:Int, count:Int, attr:String):Array<String> {
+    var s = start < 0 ? 0 : start;
+    var c = count < 0 ? 0 : count;
+    var end = s + c;
+    if (end > arr.length) end = arr.length;
+
+    var out:Array<String> = [];
+    for (i in s...end) out.push(Std.string(Reflect.field(arr[i], attr)));
+    return out;
+  }
+}

--- a/packages/core-haxe/src/frutiparc/core/UserMng.hx
+++ b/packages/core-haxe/src/frutiparc/core/UserMng.hx
@@ -1,0 +1,131 @@
+package frutiparc.core;
+
+/**
+ * Portage Haxe (noyau métier) du module AS2 UserMng.
+ * Source legacy: frutiengine/UserMng.as
+ */
+class UserMng {
+  public static function xpToLevel(xp:Float):Int {
+    var value = Math.max(0, xp);
+    return Math.floor(Math.sqrt(value / 10000) + 1);
+  }
+
+  public static function levelToXp(level:Float):Float {
+    var v = Math.max(1, level);
+    return Math.pow(v - 1, 2) * 10000;
+  }
+
+  public static function xpLevelCompletionRate(xp:Float):Float {
+    var level = xpToLevel(xp);
+    var xpOk = xp - levelToXp(level);
+    var between = levelToXp(level + 1) - levelToXp(level);
+    return xpOk / between;
+  }
+
+  public static function birthdayToAge(bd:String, now:Date):Int {
+    if (bd == null || bd == "0000-00-00" || bd.length < 10) return 0;
+    var y = Std.parseInt(bd.substr(0, 4));
+    var m = Std.parseInt(bd.substr(5, 2));
+    var d = Std.parseInt(bd.substr(8, 2));
+
+    var ly = now.getFullYear();
+    var lm = now.getMonth() + 1;
+    var ld = now.getDate();
+
+    return (lm > m || (lm == m && ld >= d)) ? ly - y : ly - y - 1;
+  }
+
+  public static function birthdayToMonthAge(bd:String, now:Date):Int {
+    if (bd == null || bd == "0000-00-00 00:00:00" || bd.length < 19) return 0;
+    var y = Std.parseInt(bd.substr(0, 4));
+    var m = Std.parseInt(bd.substr(5, 2));
+    var d = Std.parseInt(bd.substr(8, 2));
+
+    var ly = now.getFullYear();
+    var lm = now.getMonth() + 1;
+    var ld = now.getDate();
+
+    return (ly - y) * 12 + (lm - m) - (ld < d ? 1 : 0);
+  }
+
+  public static function formatInfoBasic(node:Dynamic, now:Date, langText:Dynamic):Dynamic {
+    return {
+      xpLevel: xpToLevel(Std.parseFloat(node.attributes.x)),
+      xpCompletionRate: xpLevelCompletionRate(Std.parseFloat(node.attributes.x)),
+      nickname: node.attributes.u,
+      gender: node.attributes.sx,
+      age: birthdayToAge(node.attributes.bd, now),
+      birthday: node.attributes.bd,
+      country: Lang.country(node.attributes.co, langText),
+      countryCode: node.attributes.co,
+      region: Lang.region(node.attributes.co, node.attributes.rg, langText),
+    };
+  }
+
+  public var mcList:Array<Dynamic>;
+  public var u:String;
+  public var flMode:Bool;
+  public var sortString:String;
+  public var infoBasic:Dynamic;
+
+  public function new(u:String, ?iB:Dynamic = null, ?flMode:Bool = false) {
+    this.u = u;
+    this.flMode = flMode;
+    this.mcList = [];
+    this.updateSortString();
+
+    this.infoBasic = {
+      status: { internal: null, external: null, emote: null },
+      fbouille: "000503000000111010",
+      presence: 0,
+      xpLevel: 1,
+      xpCompletionRate: 0,
+      nickname: u,
+      gender: "M",
+      age: null,
+      birthday: "",
+      country: "",
+      region: "",
+      flMute: false,
+    };
+
+    if (iB != null) {
+      for (n in Reflect.fields(iB)) Reflect.setField(this.infoBasic, n, Reflect.field(iB, n));
+    }
+  }
+
+  public function setMc(mc:Dynamic):Void {
+    if (mc == null) return;
+    if (mcList.indexOf(mc) == -1) mcList.push(mc);
+    if (this.infoBasic != null && Reflect.field(mc, "onInfoBasic") != null) mc.onInfoBasic(this.getInfoBasic());
+  }
+
+  public function unsetMc(mc:Dynamic):Void {
+    var idx = mcList.indexOf(mc);
+    if (idx >= 0) mcList.splice(idx, 1);
+  }
+
+  public function onAction(act:Dynamic):Void {
+    for (mc in mcList) if (Reflect.field(mc, "onAction") != null) mc.onAction(act);
+  }
+
+  public function onStatusObj(obj:Dynamic):Void {
+    if (obj == null) return;
+    for (n in Reflect.fields(obj)) Reflect.setField(this.infoBasic, n, Reflect.field(obj, n));
+    for (mc in mcList) if (Reflect.field(mc, "onInfoBasic") != null) mc.onInfoBasic(obj);
+  }
+
+  public function onDelete():Void {
+    this.mcList = [];
+  }
+
+  public function setInfoBasic(obj:Dynamic):Void {
+    for (n in Reflect.fields(obj)) Reflect.setField(this.infoBasic, n, Reflect.field(obj, n));
+  }
+
+  public function getInfoBasic():Dynamic return this.infoBasic;
+
+  public function updateSortString():Void {
+    this.sortString = (this.flMode ? "0" : "1") + this.u.toLowerCase();
+  }
+}

--- a/packages/core-haxe/src/frutiparc/core/WinBox.hx
+++ b/packages/core-haxe/src/frutiparc/core/WinBox.hx
@@ -1,0 +1,94 @@
+package frutiparc.core;
+
+/**
+ * Portage Haxe (noyau métier) du module AS2 WinBox.
+ * Source legacy: frutiengine/WinBox.as
+ */
+class WinBox {
+  public var initialized:Bool = false;
+  public var slot:Dynamic;
+  public var depth:Int;
+  public var flShow:Bool = false;
+  public var flActive:Bool = false;
+  public var wasShow:Bool = false;
+  public var title:String;
+  public var flClosed:Bool = false;
+  public var window:Dynamic;
+  public var mode:String;
+
+  public function new() {}
+
+  public function preInit():Void {
+    if (this.title == null) this.title = "";
+  }
+
+  public function init(slot:Dynamic, depth:Int):Bool {
+    var rs = !this.initialized;
+    if (rs) this.preInit();
+
+    this.initialized = true;
+    this.slot = slot;
+    this.depth = depth;
+    this.flShow = true;
+
+    return rs;
+  }
+
+  public function setDepth(depth:Int):Void {
+    this.depth = depth;
+  }
+
+  public function close():Void {
+    this.slot.rmBox(this);
+    this.flClosed = true;
+  }
+
+  public function tryToClose():Void {
+    this.close();
+  }
+
+  public function hide():Void {
+    this.flShow = false;
+  }
+
+  public function show():Void {
+    this.flShow = true;
+  }
+
+  public function onActivate():Void {
+    this.flActive = true;
+  }
+
+  public function onDeactivate():Void {
+    this.flActive = false;
+  }
+
+  public function onSlotActivate():Void {
+    if (this.wasShow) this.show();
+    this.wasShow = false;
+  }
+
+  public function onSlotDeactivate():Void {
+    if (this.flShow) {
+      this.wasShow = true;
+      this.hide();
+    } else {
+      this.wasShow = false;
+    }
+  }
+
+  public function activate():Void {
+    this.slot.activate(this);
+  }
+
+  public function move(newSlot:Dynamic):Bool {
+    if (this.slot == newSlot) return false;
+
+    this.slot.move(this, newSlot);
+    return true;
+  }
+
+  public function setTitle(t:String):Void {
+    this.title = t;
+  }
+}

--- a/packages/core-haxe/src/frutiparc/core/WinStandard.hx
+++ b/packages/core-haxe/src/frutiparc/core/WinStandard.hx
@@ -1,0 +1,129 @@
+package frutiparc.core;
+
+/**
+ * Portage Haxe pragmatique du module AS2 WinStandard.
+ * Focus: logique non-Flash (mode desktop/tab, recal, size/pos, titre, gelatine).
+ */
+class WinStandard extends Window {
+  public static var env:Dynamic = {
+    frameMode: false,
+    mcw: 800,
+    mch: 600,
+    cornerX: 0,
+    cornerY: 0,
+    tmod: 1,
+  };
+
+  public var pos:Dynamic;
+  public var minimum:Dynamic;
+  public var tab:Dynamic;
+  public var box:Dynamic;
+  public var title:String;
+  public var gel:Float = 0;
+  public var flResizable:Bool;
+  public var flMoveAnim:Bool;
+  public var flInterface:Bool;
+  public var xScale:Float = 100;
+  public var yScale:Float = 100;
+  public var xPos:Float = 0;
+  public var yPos:Float = 0;
+
+  public function new() {
+    super();
+    this.pos = {x: 0, y: 0, w: 0, h: 0};
+    this.minimum = {w: 0, h: 0};
+    this.tab = {w: 0, h: 0};
+    this.box = {mode: "desktop"};
+  }
+
+  override public function init():Void {
+    if (this.flInterface == null) this.flInterface = true;
+    super.init();
+    if (this.flResizable == null) this.flResizable = true;
+    if (this.flMoveAnim == null) this.flMoveAnim = true;
+  }
+
+  public function update():Void {
+    updateSize();
+    updatePos();
+  }
+
+  public function updatePos():Void {
+    if (this.box.mode == "desktop") updateDeskPos();
+    else if (this.box.mode == "tab") updateTabPos();
+  }
+
+  public function updateSize():Void {
+    if (this.box.mode == "desktop") updateDeskSize();
+    else if (this.box.mode == "tab") updateTabSize();
+  }
+
+  public function updateDeskPos():Void {
+    recal();
+    moveToPos();
+  }
+
+  public function moveToPos():Void {
+    this.xPos = this.pos.x;
+    this.yPos = this.pos.y;
+  }
+
+  public function updateDeskSize():Void {
+    this.minimum.w = Math.max(0, this.minimum.w);
+    this.minimum.h = Math.max(0, this.minimum.h);
+  }
+
+  public function updateTabPos():Void {
+    this.xPos = env.cornerX;
+    this.yPos = env.cornerY;
+  }
+
+  public function updateTabSize():Void {
+    this.tab.w = env.mcw - env.cornerX;
+    this.tab.h = env.mch - env.cornerY;
+  }
+
+  public function recal():Bool {
+    if (env.frameMode) return false;
+
+    var oldPos = {x: this.pos.x, y: this.pos.y, w: this.pos.w, h: this.pos.h};
+
+    this.pos.w = Math.max(Math.min(env.mcw - env.cornerX, this.pos.w), this.minimum.w);
+    this.pos.h = Math.max(Math.min(env.mch - env.cornerY, this.pos.h), this.minimum.h);
+    this.pos.x = Math.max(Math.min(this.pos.x, env.mcw - this.pos.w), env.cornerX);
+    this.pos.y = Math.max(Math.min(this.pos.y, env.mch - this.pos.h), env.cornerY);
+
+    return oldPos.x != this.pos.x || oldPos.y != this.pos.y || oldPos.w != this.pos.w || oldPos.h != this.pos.h;
+  }
+
+  public function resize(w:Float, h:Float):Void {
+    this.pos.w = w;
+    this.pos.h = h;
+    recal();
+    update();
+  }
+
+  public function onChangeMode():Void {
+    if (this.box.mode == "desktop") initDesktopMode();
+    else initTabMode();
+    update();
+  }
+
+  public function initDesktopMode():Void {}
+
+  public function initTabMode():Void {}
+
+  public function onStageResize():Void {
+    update();
+  }
+
+  public function setTitle(title:String):Void {
+    this.title = title;
+  }
+
+  public function gelatine():Void {
+    this.gel = (this.gel + env.tmod * 10) % 628;
+    this.xScale = 100 + Math.cos(this.gel / 100) * 4;
+    this.yScale = 100 + Math.sin(this.gel / 100) * 4;
+  }
+}

--- a/packages/core-haxe/src/frutiparc/core/Window.hx
+++ b/packages/core-haxe/src/frutiparc/core/Window.hx
@@ -1,0 +1,11 @@
+package frutiparc.core;
+
+/**
+ * Portage Haxe du module AS2 Window.
+ * Source legacy: frutiengine/Window.as
+ */
+class Window {
+  public function new() {}
+
+  public function init():Void {}
+}

--- a/packages/core-js/src/cbee.js
+++ b/packages/core-js/src/cbee.js
@@ -1,0 +1,153 @@
+/**
+ * Runtime JS mirror for pragmatic CBee subset (listener/cmd orchestration).
+ */
+class CBee {
+  constructor(o = {}) {
+    Object.assign(this, o);
+
+    this.cmdList = this.cmdList || {
+      onclose: 'onclose',
+      onconnect: 'onconnect',
+    };
+
+    this.listeners = this.listeners || {};
+    this.specificListeners = this.specificListeners || {};
+    this.connected = this.connected || false;
+    this.cnxNb = this.cnxNb || 0;
+    this.sentLog = [];
+  }
+
+  debug() {}
+
+  connect(host, port) {
+    this.host = host;
+    this.port = port;
+    this.connected = false;
+  }
+
+  onConnect(success) {
+    this.callGlobalListener('onConnect', success);
+    if (success) {
+      this.connected = true;
+      this.cnxNb += 1;
+    } else {
+      this.connected = false;
+    }
+    this.callListenersArray(this.listeners.onconnect, success);
+  }
+
+  onClose() {
+    this.callGlobalListener('onClose');
+    this.connected = false;
+    this.callListenersArray(this.listeners.onclose);
+  }
+
+  onXML(node) {
+    if (!node) return;
+
+    const cmdName = String(node.nodeName).toLowerCase();
+    this.callListenersArray(this.listeners[cmdName], node);
+
+    const attrs = node.attributes || {};
+    Object.keys(attrs).forEach((attrib) => {
+      const byCmd = this.specificListeners[cmdName];
+      if (!byCmd) return;
+      const byAttr = byCmd[attrib];
+      if (!byAttr) return;
+      this.callListenersArray(byAttr[String(attrs[attrib])], node);
+    });
+
+    this.callGlobalListener('onXML', node);
+  }
+
+  setGlobalListener(obj) {
+    this.globalListener = obj;
+  }
+
+  callGlobalListener(event, data) {
+    if (!this.globalListener) return;
+    this.globalListener.obj[this.globalListener.method](this.port, event, data);
+  }
+
+  send(x) {
+    if (!this.connected) return false;
+    this.sentLog.push(x);
+    return true;
+  }
+
+  cmd(cmd, attr, child) {
+    const cbeeCmdName = this.cmdList[String(cmd).toLowerCase()];
+    if (cbeeCmdName === undefined) return false;
+
+    const x = {
+      nodeName: cbeeCmdName,
+      attributes: { ...(attr || {}) },
+    };
+    if (child !== undefined) x.child = child;
+
+    return this.send(x);
+  }
+
+  addListener(cmd, obj, method, attrib, value) {
+    const cbeeCmd = this.cmdList[String(cmd).toLowerCase()];
+    if (cbeeCmd === undefined) return;
+
+    if (attrib === undefined) {
+      if (this.listeners[cbeeCmd] === undefined) this.listeners[cbeeCmd] = [];
+      this.listeners[cbeeCmd].push({ obj, method });
+      return;
+    }
+
+    const a = String(attrib);
+    const v = String(value);
+    if (this.specificListeners[cbeeCmd] === undefined) this.specificListeners[cbeeCmd] = {};
+    if (this.specificListeners[cbeeCmd][a] === undefined) this.specificListeners[cbeeCmd][a] = {};
+    if (this.specificListeners[cbeeCmd][a][v] === undefined) this.specificListeners[cbeeCmd][a][v] = [];
+    this.specificListeners[cbeeCmd][a][v].push({ obj, method });
+  }
+
+  removeListenerCmd(cmd, attrib, value) {
+    const cbeeCmd = this.cmdList[String(cmd).toLowerCase()];
+    if (cbeeCmd === undefined) return;
+
+    if (attrib === undefined) {
+      this.listeners[cbeeCmd] = [];
+      return;
+    }
+
+    const a = String(attrib);
+    const v = String(value);
+    if (this.specificListeners[cbeeCmd] && this.specificListeners[cbeeCmd][a]) {
+      this.specificListeners[cbeeCmd][a][v] = [];
+    }
+  }
+
+  removeListenerCmdObj(cmd, obj, attrib, value) {
+    const cbeeCmd = this.cmdList[String(cmd).toLowerCase()];
+    if (cbeeCmd === undefined) return;
+
+    if (attrib === undefined) {
+      const arr = this.listeners[cbeeCmd] || [];
+      this.listeners[cbeeCmd] = arr.filter((entry) => entry.obj !== obj);
+      return;
+    }
+
+    const a = String(attrib);
+    const v = String(value);
+    const arr = (((this.specificListeners[cbeeCmd] || {})[a] || {})[v]) || [];
+    if (this.specificListeners[cbeeCmd] && this.specificListeners[cbeeCmd][a]) {
+      this.specificListeners[cbeeCmd][a][v] = arr.filter((entry) => entry.obj !== obj);
+    }
+  }
+
+  callListenersArray(arr, node) {
+    if (!arr) return;
+    for (let i = 0; i < arr.length; i += 1) {
+      arr[i].obj[arr[i].method](node);
+    }
+  }
+}
+
+module.exports = {
+  CBee,
+};

--- a/packages/core-js/src/cbeeLc.js
+++ b/packages/core-js/src/cbeeLc.js
@@ -1,0 +1,20 @@
+/**
+ * Runtime JS mirror for Lot A target CBeeLC.
+ */
+class CBeeLC {
+  constructor(cbee) {
+    this.cbee = cbee;
+  }
+
+  send(x) {
+    return this.cbee.send(x);
+  }
+
+  cmd(a, b, c) {
+    return this.cbee.cmd(a, b, c);
+  }
+}
+
+module.exports = {
+  CBeeLC,
+};

--- a/packages/core-js/src/cbeeLocal.js
+++ b/packages/core-js/src/cbeeLocal.js
@@ -1,0 +1,222 @@
+/**
+ * Runtime JS mirror for pragmatic CBeeLocal subset.
+ * Supports both internal (CBeeManager bridge) and external (LocalConnection-like) variants.
+ */
+class CBeeLocal {
+  constructor(obj = {}) {
+    Object.assign(this, obj);
+
+    this.cmdList = this.cmdList || {
+      onclose: 'onclose',
+      onconnect: 'onconnect',
+      ident: 'ident',
+    };
+
+    this.listeners = this.listeners || {};
+    this.specificListeners = this.specificListeners || {};
+    this.initialized = false;
+    this.connected = false;
+    this.logged = false;
+
+    this.addListener('ident', this, 'onIdent');
+  }
+
+  static randomId() {
+    return Math.random().toString(36).slice(2, 10);
+  }
+
+  get isInternalMode() {
+    return this.cbeeManager !== undefined && this.cbeeManager !== null;
+  }
+
+  init() {
+    if (this.port === undefined) return;
+
+    if (this.isInternalMode) {
+      this.initialized = true;
+      this.cbeeLC = this.cbeeManager.addListener(this.port, this, true);
+
+      const obj = this.cbeeManager.getStatus(this.port);
+      if (obj && obj.connected) this.onConnect(true);
+      if (obj && obj.logged) this.callListenersArray(this.listeners[this.cmdList.ident]);
+      return;
+    }
+
+    const sid = this.sid;
+    const makeConnection = this.localConnectionFactory;
+    if (sid === undefined || typeof makeConnection !== 'function') return;
+
+    if (!this.lcName) this.lcName = `fp_cblc_${sid}_${this.port}_${CBeeLocal.randomId()}`;
+    if (!this.managerChannel) this.managerChannel = `fp_cbeeMng_${sid}`;
+
+    if (this.inboundConnection && typeof this.inboundConnection.connect === 'function') {
+      this.inboundConnection.connect(this.lcName);
+    }
+
+    const lc = makeConnection();
+    lc.obj = this;
+    lc.onStatus = (obj) => {
+      if (obj && obj.level === 'error') this.looseLocalConnection();
+      else this.initialized = true;
+    };
+    lc.send(this.managerChannel, 'addListener', this.port, this.lcName);
+    lc.send(this.managerChannel, 'getStatus', this.port, this.lcName);
+  }
+
+  close() {
+    if (this.cbeeManager) this.cbeeManager.removeListener(this.port, this);
+  }
+
+  check() {}
+
+  looseLocalConnection() {
+    this.initialized = false;
+    this.onClose();
+  }
+
+  onConnect(success) {
+    this.connected = !!success;
+    this.logged = false;
+    this.callListenersArray(this.listeners.onconnect, success);
+  }
+
+  onClose() {
+    this.connected = false;
+    this.logged = false;
+    this.callListenersArray(this.listeners.onclose);
+  }
+
+  onXML(node) {
+    const cmdName = String(node.nodeName).toLowerCase();
+    this.callListenersArray(this.listeners[cmdName], node);
+
+    const attrs = node.attributes || {};
+    Object.keys(attrs).forEach((attrib) => {
+      const byCmd = this.specificListeners[cmdName];
+      if (!byCmd) return;
+      const byAttr = byCmd[attrib];
+      if (!byAttr) return;
+      this.callListenersArray(byAttr[String(attrs[attrib])], node);
+    });
+  }
+
+  onStatus(obj) {
+    if (obj && obj.connected) this.onConnect(true);
+    this.logged = !!(obj && obj.logged);
+  }
+
+  send(s) {
+    if (this.isInternalMode) {
+      if (!this.initialized) return false;
+      if (!this.cbeeLC || typeof this.cbeeLC.send !== 'function') return false;
+      this.cbeeLC.send(s);
+      return true;
+    }
+
+    if (!this.initialized || !this.connected) return false;
+    if (typeof this.localConnectionFactory !== 'function') return false;
+
+    const lc = this.localConnectionFactory();
+    lc.obj = this;
+    lc.onStatus = (obj) => {
+      if (obj && obj.level === 'error') this.looseLocalConnection();
+    };
+    const channel = this.serverChannel || `fp_cbee_${this.port}_${this.sid}`;
+    lc.send(channel, 'send', s);
+    return true;
+  }
+
+  cmd(cmd, attr, child) {
+    if (!this.isInternalMode) {
+      if (!this.initialized || !this.connected) return false;
+      if (typeof this.localConnectionFactory !== 'function') return false;
+      const lc = this.localConnectionFactory();
+      lc.obj = this;
+      lc.onStatus = (obj) => {
+        if (obj && obj.level === 'error') this.looseLocalConnection();
+      };
+      const channel = this.serverChannel || `fp_cbee_${this.port}_${this.sid}`;
+      lc.send(channel, 'cmd', cmd, attr, child);
+      return true;
+    }
+
+    const cbeeCmdName = this.cmdList[String(cmd).toLowerCase()];
+    if (cbeeCmdName === undefined) return false;
+
+    const x = {
+      nodeName: cbeeCmdName,
+      attributes: { ...(attr || {}) },
+    };
+    if (child !== undefined) x.child = child;
+
+    return this.send(x);
+  }
+
+  onIdent(node) {
+    this.connected = true;
+    this.logged = !(node && node.attributes && node.attributes.k !== undefined);
+  }
+
+  addListener(cmd, obj, method, attrib, value) {
+    const cbeeCmd = this.cmdList[String(cmd).toLowerCase()];
+    if (cbeeCmd === undefined) return;
+
+    if (attrib === undefined) {
+      if (this.listeners[cbeeCmd] === undefined) this.listeners[cbeeCmd] = [];
+      this.listeners[cbeeCmd].push({ obj, method });
+      return;
+    }
+
+    const a = String(attrib);
+    const v = String(value);
+    if (this.specificListeners[cbeeCmd] === undefined) this.specificListeners[cbeeCmd] = {};
+    if (this.specificListeners[cbeeCmd][a] === undefined) this.specificListeners[cbeeCmd][a] = {};
+    if (this.specificListeners[cbeeCmd][a][v] === undefined) this.specificListeners[cbeeCmd][a][v] = [];
+    this.specificListeners[cbeeCmd][a][v].push({ obj, method });
+  }
+
+  removeListenerCmd(cmd, attrib, value) {
+    const cbeeCmd = this.cmdList[String(cmd).toLowerCase()];
+    if (cbeeCmd === undefined) return;
+
+    if (attrib === undefined) {
+      this.listeners[cbeeCmd] = [];
+      return;
+    }
+
+    const a = String(attrib);
+    const v = String(value);
+    if (this.specificListeners[cbeeCmd] && this.specificListeners[cbeeCmd][a]) {
+      this.specificListeners[cbeeCmd][a][v] = [];
+    }
+  }
+
+  removeListenerCmdObj(cmd, obj, attrib, value) {
+    const cbeeCmd = this.cmdList[String(cmd).toLowerCase()];
+    if (cbeeCmd === undefined) return;
+
+    if (attrib === undefined) {
+      const arr = this.listeners[cbeeCmd] || [];
+      this.listeners[cbeeCmd] = arr.filter((entry) => entry.obj !== obj);
+      return;
+    }
+
+    const a = String(attrib);
+    const v = String(value);
+    const arr = (((this.specificListeners[cbeeCmd] || {})[a] || {})[v]) || [];
+    if (this.specificListeners[cbeeCmd] && this.specificListeners[cbeeCmd][a]) {
+      this.specificListeners[cbeeCmd][a][v] = arr.filter((entry) => entry.obj !== obj);
+    }
+  }
+
+  callListenersArray(arr, node) {
+    if (!arr) return;
+    for (let i = 0; i < arr.length; i += 1) {
+      arr[i].obj[arr[i].method](node);
+    }
+  }
+}
+
+module.exports = {
+  CBeeLocal,
+};

--- a/packages/core-js/src/cbeeManager.js
+++ b/packages/core-js/src/cbeeManager.js
@@ -1,0 +1,112 @@
+const { CBee } = require('./cbee');
+const { CBeeLC } = require('./cbeeLc');
+
+/**
+ * Runtime JS mirror for pragmatic CBeeManager subset.
+ */
+class CBeeManager {
+  constructor(o = {}) {
+    this.className = 'CBee';
+    this.timeout = 1000;
+    this.cnxTimeout = 60000;
+    this.cbeeCnx = {};
+    this.host = 'localhost';
+    this.now = () => Date.now();
+    Object.assign(this, o);
+  }
+
+  addListener(port, lc, notRecallMe) {
+    if (port === undefined || lc === undefined) return undefined;
+
+    const key = String(port);
+    if (this.cbeeCnx[key] === undefined) {
+      this.addCnx(port, false);
+    } else if (!this.cbeeCnx[key].cbee.connected) {
+      this.cbeeCnx[key].cbee.connect(this.host, port);
+    } else if (!notRecallMe && this.cbeeCnx[key].cbee.logged && typeof lc.onXML === 'function') {
+      lc.onXML({ nodeName: this.cbeeCnx[key].cbee.cmdList.ident, attributes: { l: this.cbeeCnx[key].cbee.login } });
+    }
+
+    const listeners = this.cbeeCnx[key].listeners;
+    if (!listeners.includes(lc)) listeners.push(lc);
+    return this.cbeeCnx[key].lc;
+  }
+
+  getStatus(port, lc) {
+    const cc = this.cbeeCnx[String(port)];
+    if (!cc) return undefined;
+
+    const obj = {
+      connected: cc.cbee.connected,
+      logged: !!cc.cbee.logged,
+    };
+
+    if (lc && typeof lc.onStatus === 'function') lc.onStatus(obj);
+    return obj;
+  }
+
+  removeListener(port, lc, forceClose = false) {
+    const cc = this.cbeeCnx[String(port)];
+    if (!cc) return;
+
+    cc.listeners = cc.listeners.filter((entry) => entry !== lc);
+
+    if (cc.listeners.length === 0) {
+      if (forceClose) this.removeCnx(port);
+      else cc.emptyTime = this.now();
+    }
+  }
+
+  addCnx(port, force = false, obj) {
+    const cbee = new CBee(obj);
+    cbee.connect(this.host, port);
+    cbee.setGlobalListener({ obj: this, method: 'onGlobalListener' });
+
+    const lc = new CBeeLC(cbee);
+    this.cbeeCnx[String(port)] = {
+      cbee,
+      lc,
+      listeners: [],
+      emptyTime: this.now(),
+      force,
+    };
+
+    return cbee;
+  }
+
+  removeCnx(port) {
+    const key = String(port);
+    if (!this.cbeeCnx[key]) return;
+
+    this.cbeeCnx[key].cbee.setGlobalListener(undefined);
+    delete this.cbeeCnx[key];
+  }
+
+  onGlobalListener(port, event, data) {
+    const cc = this.cbeeCnx[String(port)];
+    if (!cc) return;
+
+    if (event === 'onClose' && !cc.force && cc.listeners.length === 0) {
+      this.removeCnx(port);
+      return;
+    }
+
+    for (let i = 0; i < cc.listeners.length; i += 1) {
+      const e = cc.listeners[i];
+      if (e && typeof e[event] === 'function') e[event](data);
+    }
+  }
+
+  checkAll() {
+    Object.keys(this.cbeeCnx).forEach((port) => {
+      const cc = this.cbeeCnx[port];
+      if (!cc.force && cc.listeners.length === 0 && this.now() - cc.emptyTime > this.cnxTimeout) {
+        this.removeCnx(port);
+      }
+    });
+  }
+}
+
+module.exports = {
+  CBeeManager,
+};

--- a/packages/core-js/src/classLoader.js
+++ b/packages/core-js/src/classLoader.js
@@ -1,0 +1,95 @@
+/**
+ * Runtime mirror of frutiparc/main/classLoader.as workflow.
+ * Tracks sequential library loading and triggers `play` when all libs are loaded.
+ */
+class ClassLoader {
+  constructor(obj = {}) {
+    Object.assign(this, obj);
+
+    this.libPath = this.libPath || [
+      'bumdum.swf',
+      'skool.swf',
+      'fe.swf',
+      'box.swf',
+      'root.swf',
+      'frusion.swf',
+      'interface.swf',
+      'listener.swf',
+      'unsorted.swf',
+    ];
+    this.baseUrl = this.baseUrl || 'http://www.beta.frutiparc.com/swf/lib/';
+
+    this.logText = '';
+    this.libToLoad = this.libPath.length;
+    this.libLoaded = 0;
+    this.state = 'stopped';
+
+    this.clips = {};
+
+    if (this.loader) this.attachLoaderListeners(this.loader);
+  }
+
+  attachLoaderListeners(loader) {
+    this.loader = loader;
+    if (typeof loader.addListener === 'function') loader.addListener(this);
+  }
+
+  play() {
+    this.state = 'playing';
+    if (typeof this.onPlay === 'function') this.onPlay();
+  }
+
+  stop() {
+    this.state = 'stopped';
+  }
+
+  createEmptyMovieClip(name, depth) {
+    const mc = { name, depth, url: null };
+    this.clips[name] = mc;
+    return mc;
+  }
+
+  initLoad(id) {
+    const name = `lib${id}`;
+    const mc = this.createEmptyMovieClip(name, 80 + id);
+    const url = `${this.baseUrl}${this.libPath[id]}`;
+    mc.url = url;
+
+    if (this.loader && typeof this.loader.loadClip === 'function') {
+      this.loader.loadClip(url, mc);
+    }
+
+    return { mc, url };
+  }
+
+  start() {
+    this.stop();
+    this.libToLoad = this.libPath.length;
+    this.libLoaded = 0;
+    this.logText = '';
+    return this.initLoad(0);
+  }
+
+  onLoadComplete(mc) {
+    this.logText += `loadComplete(${mc.name || mc})\n`;
+    this.libLoaded += 1;
+
+    if (this.libLoaded >= this.libToLoad) {
+      this.play();
+    } else {
+      this.initLoad(this.libLoaded);
+    }
+  }
+
+  onLoadError(mc, error) {
+    this.logText += `loadError(${error})\n`;
+  }
+
+  onLoadStart(mc) {
+    this.logText += `loadStart(${mc.name || mc})\n`;
+  }
+}
+
+module.exports = {
+  ClassLoader,
+};

--- a/packages/core-js/src/desktop.js
+++ b/packages/core-js/src/desktop.js
@@ -1,0 +1,20 @@
+const { SlotBase } = require('./slotBase');
+
+/**
+ * Runtime JS mirror for Lot A target Desktop.
+ */
+class Desktop extends SlotBase {
+  constructor() {
+    super();
+    this.iconList = [];
+  }
+
+  init(slotList, depth, flGo) {
+    super.init(slotList, depth, flGo);
+    this.iconList = [];
+  }
+}
+
+module.exports = {
+  Desktop,
+};

--- a/packages/core-js/src/fFileMng.js
+++ b/packages/core-js/src/fFileMng.js
@@ -1,0 +1,103 @@
+/**
+ * Runtime JS mirror for Lot A target FFileMng (tree parsing logic).
+ */
+class FFileMng {
+  constructor() {
+    this.tree = {};
+    this.messages = '';
+    this.inbox = '';
+    this.blackbox = '';
+    this.draftbox = '';
+    this.outbox = '';
+    this.disccollector = '';
+    this.inventory = '';
+    this.mycontact = '';
+    this.recyclebin = '';
+  }
+
+  onLoadTree(success, data) {
+    if (!success) return false;
+
+    const bFolder = String(data.lastChild.attributes.b).split(';');
+    this.messages = bFolder[0];
+    this.inbox = bFolder[1];
+    this.outbox = bFolder[2];
+    this.blackbox = bFolder[3];
+    this.draftbox = bFolder[4];
+    this.disccollector = bFolder[5];
+    this.inventory = bFolder[6];
+    this.mycontact = bFolder[7];
+    this.recyclebin = bFolder[8];
+
+    return this.analyseTree(data.lastChild, undefined);
+  }
+
+  analyseTree(node, parent) {
+    let cur = node;
+    while (cur && cur.nodeType > 0) {
+      if (cur.nodeName === 'f' || cur.nodeName === 's') {
+        if (cur.attributes.u === undefined) cur.attributes.u = 'root';
+
+        this.tree[cur.attributes.u] = {
+          name: cur.attributes.n,
+          type: cur.attributes.t,
+          tpl: cur.attributes.p,
+          childs: [],
+          parent,
+        };
+
+        if (parent !== undefined && cur.nodeName === 'f') {
+          this.tree[parent].childs.push(cur.attributes.u);
+        }
+
+        if (typeof cur.hasChildNodes === 'function' && cur.hasChildNodes()) {
+          this.analyseTree(cur.firstChild, cur.attributes.u);
+        }
+      }
+      cur = cur.nextSibling;
+    }
+    return true;
+  }
+
+  analyseXml(d) {
+    const infos = this.tree[d.attributes.u];
+    if (infos === undefined) return undefined;
+
+    const l = {
+      uid: d.attributes.u,
+      type: 'folder',
+      desc: [infos.name, infos.type],
+      tpl: infos.tpl,
+      parent: infos.parent,
+      list: [],
+    };
+
+    for (let n = d.firstChild; n && n.nodeType > 0; n = n.nextSibling) {
+      if (!this.isFileValid(n)) continue;
+
+      if (n.nodeName === 'e') {
+        l.list.push({
+          uid: n.attributes.u,
+          type: n.attributes.t,
+          size: n.attributes.s,
+          date: n.attributes.d,
+          access: n.attributes.a,
+          desc: String(n.firstChild.nodeValue).split('\r\n'),
+          parent: d.attributes.u,
+        });
+      } else if (n.nodeName === 'f') {
+        l.list.push(this.analyseXml(n));
+      }
+    }
+    return l;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  isFileValid(_node) {
+    return true;
+  }
+}
+
+module.exports = {
+  FFileMng,
+};

--- a/packages/core-js/src/feColor.js
+++ b/packages/core-js/src/feColor.js
@@ -1,0 +1,20 @@
+/**
+ * Runtime JS mirror for first Lot A migration target.
+ * This mirrors the Haxe FEColor API so Node-side tests/integration can start now.
+ */
+
+function toRGBObj(nb) {
+  const r = (nb >> 16) & 255;
+  const g = (nb >> 8) & 255;
+  const b = nb & 255;
+  return { r, g, b };
+}
+
+function toRGBInt(obj) {
+  return obj.r * 256 * 256 + obj.g * 256 + obj.b;
+}
+
+module.exports = {
+  toRGBObj,
+  toRGBInt,
+};

--- a/packages/core-js/src/feDate.js
+++ b/packages/core-js/src/feDate.js
@@ -1,0 +1,68 @@
+const FENumber = require('./feNumber');
+
+/**
+ * Runtime JS mirror for Lot A target FEDate (subset).
+ */
+
+function newFromString(str) {
+  const y = Number(str.substr(0, 4));
+  const m = Number(str.substr(5, 2));
+  const d = Number(str.substr(8, 2));
+
+  const h = Number(str.substr(11, 2));
+  const i = Number(str.substr(14, 2));
+  const s = Number(str.substr(17, 2));
+
+  const date = new Date();
+  date.setFullYear(y, m - 1, d);
+  if (!Number.isNaN(h)) date.setHours(h);
+  if (!Number.isNaN(i)) date.setMinutes(i);
+  if (!Number.isNaN(s)) date.setSeconds(s);
+  date.setMilliseconds(0);
+  return date;
+}
+
+function newFromTime(t) {
+  const date = new Date();
+  date.setTime(t);
+  return date;
+}
+
+function getObject(d) {
+  return {
+    y: FENumber.toStringL(d.getFullYear(), 4),
+    m: FENumber.toStringL(d.getMonth() + 1, 2),
+    d: FENumber.toStringL(d.getDate(), 2),
+    h: FENumber.toStringL(d.getHours(), 2),
+    i: FENumber.toStringL(d.getMinutes(), 2),
+    s: FENumber.toStringL(d.getSeconds(), 2),
+  };
+}
+
+function getCompleteObject(d) {
+  let b = d.getDay();
+  if (b === 0) b = 7;
+
+  return {
+    y: FENumber.toStringL(d.getYear() % 100, 2),
+    Y: FENumber.toStringL(d.getFullYear(), 4),
+    b: FENumber.toStringL(b, 1),
+    d: FENumber.toStringL(d.getDate(), 1),
+    D: FENumber.toStringL(d.getDate(), 2),
+    n: FENumber.toStringL(d.getMonth() + 1, 1),
+    N: FENumber.toStringL(d.getMonth() + 1, 2),
+    h: FENumber.toStringL(d.getHours(), 1),
+    H: FENumber.toStringL(d.getHours(), 2),
+    i: FENumber.toStringL(d.getMinutes(), 1),
+    I: FENumber.toStringL(d.getMinutes(), 2),
+    s: FENumber.toStringL(d.getSeconds(), 1),
+    S: FENumber.toStringL(d.getSeconds(), 2),
+  };
+}
+
+module.exports = {
+  newFromString,
+  newFromTime,
+  getObject,
+  getCompleteObject,
+};

--- a/packages/core-js/src/feNumber.js
+++ b/packages/core-js/src/feNumber.js
@@ -1,0 +1,71 @@
+/**
+ * Runtime JS mirror for Lot A target FENumber (subset).
+ */
+
+function toColorObj(nb) {
+  return {
+    r: (nb >> 16) & 0xff,
+    g: (nb >> 8) & 0xff,
+    b: nb & 0xff,
+  };
+}
+
+function base36Char(v) {
+  return '0123456789abcdefghijklmnopqrstuvwxyz'.charAt(v);
+}
+
+function toAlphaString(nb) {
+  if (nb > 26) {
+    let next;
+    if (nb % 26 === 0) {
+      next = toAlphaString(Math.floor((nb - 1) / 26));
+      nb = 26;
+    } else {
+      next = toAlphaString(Math.floor(nb / 26));
+      nb %= 26;
+    }
+    nb += 9;
+    return next + base36Char(nb);
+  }
+  return base36Char(nb + 9);
+}
+
+function encode62(n, strlen = 1) {
+  let ret = '';
+  let value = n;
+  while (value > 0) {
+    const t = value % 62;
+    if (t < 36) ret = base36Char(t).toLowerCase() + ret;
+    else ret = base36Char(t - 26).toUpperCase() + ret;
+    value = (value - t) / 62;
+  }
+  while (strlen > ret.length) ret = `0${ret}`;
+  return ret;
+}
+
+function toStringL(n, l) {
+  const value = Number.isNaN(Number(n)) || n == null ? 0 : Number(n);
+  let s = String(Math.trunc(value));
+  while (s.length < l) s = `0${s}`;
+  return s;
+}
+
+function clamp(v) {
+  return Math.min(Math.max(0, v), 255);
+}
+
+function modCol(nb, inc = 0, coef = 1) {
+  const c = toColorObj(nb);
+  const r = clamp(Math.round((c.r + inc) * coef));
+  const g = clamp(Math.round((c.g + inc) * coef));
+  const b = clamp(Math.round((c.b + inc) * coef));
+  return (r << 16) + (g << 8) + b;
+}
+
+module.exports = {
+  toColorObj,
+  toAlphaString,
+  encode62,
+  toStringL,
+  modCol,
+};

--- a/packages/core-js/src/feObject.js
+++ b/packages/core-js/src/feObject.js
@@ -1,0 +1,47 @@
+/**
+ * Runtime JS mirror for Lot A target FEObject.
+ */
+
+function clone(obj) {
+  const r = {};
+  // eslint-disable-next-line guard-for-in
+  for (const f in obj) {
+    r[f] = obj[f];
+  }
+  return r;
+}
+
+function recursiveClone(obj) {
+  const r = {};
+  // eslint-disable-next-line guard-for-in
+  for (const f in obj) {
+    const value = obj[f];
+    if (value !== null && typeof value === 'object') {
+      r[f] = recursiveClone(value);
+    } else {
+      r[f] = value;
+    }
+  }
+  return r;
+}
+
+function addObject(obj, o, splash = false) {
+  // eslint-disable-next-line guard-for-in
+  for (const element in o) {
+    if (obj[element] === undefined || splash) {
+      obj[element] = o[element];
+    }
+  }
+}
+
+function toColNumber(obj) {
+  const str = `0x${obj.r.toString(16)}${obj.g.toString(16)}${obj.b.toString(16)}`;
+  return Number(str);
+}
+
+module.exports = {
+  clone,
+  recursiveClone,
+  addObject,
+  toColNumber,
+};

--- a/packages/core-js/src/feString.js
+++ b/packages/core-js/src/feString.js
@@ -1,0 +1,128 @@
+/**
+ * Runtime JS mirror for Lot A target FEString (subset).
+ */
+
+function replace(str, search, repl) {
+  if (search.length === 0) return str;
+  return str.split(search).join(repl);
+}
+
+function decode62(n) {
+  let r = 0;
+  let coef = 1;
+  for (let i = n.length - 1; i >= 0; i -= 1) {
+    const c = n.substr(i, 1);
+    let t;
+    if (c.toLowerCase() === c) {
+      t = Number.parseInt(c, 36);
+    } else {
+      t = Number.parseInt(c.toLowerCase(), 36) + 26;
+    }
+    r += t * coef;
+    coef *= 62;
+  }
+  return r;
+}
+
+function unHTML(r) {
+  if (r.length <= 0) return r;
+  return replace(replace(replace(r, '&', '&amp;'), '<', '&lt;'), '>', '&gt;');
+}
+
+function rmChr(r, aChar) {
+  if (r.length <= 0) return r;
+  return replace(r, aChar, '');
+}
+
+function ltrim(str) {
+  let i = 0;
+  while (i < str.length && (str.substr(i, 1) === ' ' || str.substr(i, 1) === String.fromCharCode(13))) i += 1;
+  return str.substring(i);
+}
+
+function rtrim(str) {
+  let i = str.length - 1;
+  while (i >= 0 && (str.substr(i, 1) === ' ' || str.substr(i, 1) === String.fromCharCode(13))) i -= 1;
+  return str.substr(0, i + 1);
+}
+
+function trim(str) {
+  return ltrim(rtrim(str));
+}
+
+function repeat(str, l) {
+  let r = '';
+  for (let i = 0; i < l; i += 1) r += str;
+  return r;
+}
+
+function countUpperCase(str) {
+  let count = 0;
+  for (let i = 0; i < str.length; i += 1) {
+    const t = str.substr(i, 1);
+    if (t !== t.toLowerCase()) count += 1;
+  }
+  return count;
+}
+
+function startsWith(str1, str2) {
+  return str1.substr(0, str2.length) === str2;
+}
+
+function endsWith(str1, str2) {
+  return str1.substr(str1.length - str2.length) === str2;
+}
+
+function checkRepeat(str, max) {
+  if (str.length === 0) return false;
+  let last = str.charAt(0);
+  let nb = 1;
+  for (let i = 1; i < str.length; i += 1) {
+    const j = str.charAt(i);
+    if (j === last) nb += 1;
+    else {
+      nb = 1;
+      last = j;
+    }
+    if (nb > max) return true;
+  }
+  return false;
+}
+
+function replaceBackSlashN(r) {
+  return replace(r, '\\n', '\n');
+}
+
+
+function formatVars(str, obj) {
+  let pos = str.indexOf('$');
+  while (pos > -1) {
+    const n = str.substr(pos + 1, 1);
+    if (n === '$') {
+      str = `${str.substr(0, pos)}$${str.substring(pos + 2, str.length)}`;
+      pos = str.indexOf('$', pos + 2);
+    } else {
+      const r = obj[n];
+      str = `${str.substr(0, pos)}${r}${str.substring(pos + 2, str.length)}`;
+      pos = str.indexOf('$', pos + String(r).length);
+    }
+  }
+  return str;
+}
+
+module.exports = {
+  replace,
+  decode62,
+  unHTML,
+  rmChr,
+  ltrim,
+  rtrim,
+  trim,
+  repeat,
+  countUpperCase,
+  startsWith,
+  endsWith,
+  checkRepeat,
+  replaceBackSlashN,
+  formatVars,
+};

--- a/packages/core-js/src/fecmItem.js
+++ b/packages/core-js/src/fecmItem.js
@@ -1,0 +1,21 @@
+/**
+ * Runtime JS mirror for Lot A target FECMItem.
+ */
+class FECMItem {
+  constructor(caption, callBack, flSeparatorBefore, flEnabled, flVisible) {
+    this.caption = caption;
+    this.callBack = callBack;
+    this.flSeparatorBefore = flSeparatorBefore;
+    this.flEnabled = flEnabled;
+    this.flVisible = flVisible;
+  }
+
+  static onSelect(_mc, menuItem) {
+    const fn = menuItem.callBack.obj[menuItem.callBack.method];
+    return fn.call(menuItem.callBack.obj, menuItem.callBack.args);
+  }
+}
+
+module.exports = {
+  FECMItem,
+};

--- a/packages/core-js/src/femc.js
+++ b/packages/core-js/src/femc.js
@@ -1,0 +1,121 @@
+const { toColorObj } = require('./feNumber');
+
+/**
+ * Runtime JS mirror for pragmatic FEMC subset.
+ */
+class FEMC {
+  static setColor(mc, o, negFlag = false) {
+    let col;
+    if (o && o.r !== undefined) {
+      col = {
+        rb: o.r,
+        gb: o.g,
+        bb: o.b,
+        ab: o.a === undefined ? 0 : o.a,
+      };
+    } else if (typeof o === 'number') {
+      col = {
+        rb: (o >> 16) & 255,
+        gb: (o >> 8) & 255,
+        bb: o & 255,
+      };
+    } else {
+      return null;
+    }
+
+    if (negFlag) {
+      col.ra = -100;
+      col.ga = -100;
+      col.ba = -100;
+    } else {
+      col.ra = 100;
+      col.ga = 100;
+      col.ba = 100;
+      col.rb -= 255;
+      col.gb -= 255;
+      col.bb -= 255;
+    }
+
+    mc.lastTransform = col;
+    return col;
+  }
+
+  static setPColor(mc, color, percent) {
+    let c = color;
+    if (typeof color === 'number') c = toColorObj(color);
+
+    if (mc.colorObject === undefined) {
+      mc.colorObject = {
+        actual: {
+          col: { r: 0, g: 0, b: 0 },
+          percent: 100,
+        },
+      };
+    }
+
+    if (c !== undefined) mc.colorObject.actual = { col: c, percent };
+
+    const act = mc.colorObject.actual;
+    const coef = (100 - act.percent) / 100;
+    const tr = {
+      ra: act.percent,
+      ga: act.percent,
+      ba: act.percent,
+      aa: 100,
+      rb: act.col.r * coef,
+      gb: act.col.g * coef,
+      bb: act.col.b * coef,
+      ab: 0,
+    };
+
+    mc.lastTransform = tr;
+    return tr;
+  }
+
+  static killColor(mc) {
+    const tr = {
+      ra: 100,
+      ga: 100,
+      ba: 100,
+      aa: 100,
+      rb: 0,
+      gb: 0,
+      bb: 0,
+      ab: 0,
+    };
+    mc.lastTransform = tr;
+    return tr;
+  }
+
+  static morphToButton(mc) {
+    mc.onRollOver = function onRollOver() {
+      this.gotoAndStop(2);
+      if (typeof this.onFrutiRollOver === 'function') this.onFrutiRollOver();
+    };
+    mc.onRollOut = function onRollOut() {
+      this.gotoAndStop(1);
+      if (typeof this.onFrutiRollOut === 'function') this.onFrutiRollOut();
+    };
+    mc.onPress = function onPress() {
+      this.gotoAndStop(3);
+      if (typeof this.onFrutiPress === 'function') this.onFrutiPress();
+    };
+    mc.onRelease = function onRelease() {
+      this.gotoAndStop(2);
+      if (typeof this.onFrutiRelease === 'function') this.onFrutiRelease();
+    };
+    if (typeof mc.stop === 'function') mc.stop();
+  }
+
+  static toString(mc, l = 0) {
+    if (mc && mc.isRoot) return '_root';
+    if (l > 10) return '..';
+
+    if (l === 0) return `[MovieClip: ${FEMC.toString(mc._parent, l + 1)}.${mc._name}]`;
+    return `${FEMC.toString(mc._parent, l + 1)}.${mc._name}`;
+  }
+}
+
+module.exports = {
+  FEMC,
+};

--- a/packages/core-js/src/femcLoader.js
+++ b/packages/core-js/src/femcLoader.js
@@ -1,0 +1,61 @@
+/**
+ * Runtime JS mirror for Lot A target FEMCLoader.
+ */
+class FEMCLoader {
+  static urlList = {};
+
+  constructor(loadFn = null, onCompleteHook = null) {
+    this.url = undefined;
+    this.wasFirst = false;
+    this.loadFn = loadFn;
+    this.onCompleteHook = onCompleteHook;
+  }
+
+  doLoad(url, target) {
+    if (typeof this.loadFn === 'function') {
+      return this.loadFn(url, target);
+    }
+    return null;
+  }
+
+  loadClip(url, target, force = false) {
+    if (force) {
+      return this.doLoad(url, target);
+    }
+
+    if (FEMCLoader.urlList[url] === undefined) {
+      this.wasFirst = true;
+      FEMCLoader.urlList[url] = { loaded: false, objList: [] };
+      this.url = url;
+      return this.doLoad(url, target);
+    }
+
+    this.wasFirst = false;
+    const o = FEMCLoader.urlList[url];
+    if (o.loaded) {
+      return this.doLoad(url, target);
+    }
+
+    o.objList.push({ obj: this, mc: target });
+    return null;
+  }
+
+  onLoadComplete(mc) {
+    if (this.wasFirst) {
+      const o = FEMCLoader.urlList[this.url];
+      o.loaded = true;
+      for (let i = 0; i < o.objList.length; i += 1) {
+        o.objList[i].obj.loadClip(this.url, o.objList[i].mc, true);
+      }
+      o.objList = [];
+    }
+
+    if (typeof this.onCompleteHook === 'function') {
+      this.onCompleteHook(mc);
+    }
+  }
+}
+
+module.exports = {
+  FEMCLoader,
+};

--- a/packages/core-js/src/fileLoader.js
+++ b/packages/core-js/src/fileLoader.js
@@ -1,0 +1,95 @@
+/**
+ * Runtime JS mirror for Lot A target FileLoader (state + event flow).
+ */
+class FileLoader {
+  constructor(url, size = undefined, loader = null) {
+    this.url = url;
+    this.size = size;
+    this.loader = loader;
+
+    this.mc = null;
+    this.loaded = false;
+    this.bytesTotal = 0;
+    this.bytesLoaded = 0;
+    this.bytesToLoad = 0;
+    this.percent = 0;
+    this.timeStart = 0;
+    this.timeElapsed = 0;
+    this.estimatedTimeLeft = 0;
+    this.transferRate = 0;
+
+    this.listeners = [];
+  }
+
+  addListener(listener) {
+    this.listeners.push(listener);
+  }
+
+  removeListener(listener) {
+    this.listeners = this.listeners.filter((l) => l !== listener);
+  }
+
+  broadcastMessage(method, ...args) {
+    for (const l of this.listeners) {
+      if (typeof l[method] === 'function') {
+        l[method](...args);
+      }
+    }
+  }
+
+  loadClip(mc, now = Date.now()) {
+    this.mc = mc;
+    this.timeStart = now;
+    if (this.loader && typeof this.loader.loadClip === 'function') {
+      this.loader.loadClip(this.url, this.mc, this);
+    }
+  }
+
+  onLoadError(a, b) {
+    this.loaded = false;
+    this.broadcastMessage('onFileNotFoundError', a, b);
+  }
+
+  onLoadStart() {
+    this.broadcastMessage('onLoadStart');
+  }
+
+  onLoadProgress(mc, loadedBytes, totalBytes, now = Date.now()) {
+    this.bytesLoaded = loadedBytes;
+    this.bytesTotal = totalBytes;
+    this.bytesToLoad = this.bytesTotal - this.bytesLoaded;
+    this.percent = this.bytesTotal === 0 ? 0 : Math.round((this.bytesLoaded * 10000) / this.bytesTotal) / 100;
+
+    this.timeElapsed = now - this.timeStart;
+    this.transferRate = this.timeElapsed <= 0 ? 0 : this.bytesLoaded / this.timeElapsed;
+    this.estimatedTimeLeft = this.transferRate <= 0 ? 0 : this.bytesToLoad / this.transferRate;
+
+    this.broadcastMessage('onLoadProgress', mc, loadedBytes, totalBytes);
+  }
+
+  onLoadComplete(progress = null) {
+    if (progress) {
+      this.bytesLoaded = progress.bytesLoaded;
+      this.bytesTotal = progress.bytesTotal;
+    }
+
+    if (this.size === undefined || this.size === this.bytesLoaded) {
+      this.loaded = true;
+      this.broadcastMessage('onLoadComplete');
+    } else {
+      this.broadcastMessage('onFalseSizeError');
+    }
+  }
+
+  onLoadInit() {
+    if (this.size === undefined || this.size === this.bytesLoaded) {
+      this.broadcastMessage('onLoadInit');
+    } else {
+      this.broadcastMessage('onFalseSizeError');
+    }
+  }
+}
+
+module.exports = {
+  FileLoader,
+};

--- a/packages/core-js/src/http.js
+++ b/packages/core-js/src/http.js
@@ -1,0 +1,60 @@
+const FEObject = require('./feObject');
+
+/**
+ * Runtime JS mirror for Lot A target HTTP (queue + callback orchestration only).
+ */
+class HTTP {
+  static queue = [];
+  static flIdle = true;
+  static defaultParams = {};
+  static defaultHeaders = {};
+
+  constructor(action, params, callback, method = 'GET', extra = null, transport = null) {
+    this.action = action;
+    this.params = params || {};
+    this.callback = callback;
+    this.method = method;
+    this.extra = extra;
+    this.transport = transport;
+
+    this.output = FEObject.clone(HTTP.defaultParams);
+    FEObject.addObject(this.output, this.params, true);
+
+    HTTP.submitMe(this);
+  }
+
+  static submitMe(obj) {
+    if (HTTP.flIdle) {
+      HTTP.flIdle = false;
+      obj.submit();
+    } else {
+      HTTP.queue.push(obj);
+    }
+  }
+
+  static goNext() {
+    if (HTTP.queue.length === 0) {
+      HTTP.flIdle = true;
+    } else {
+      const t = HTTP.queue.shift();
+      t.submit();
+    }
+  }
+
+  submit() {
+    if (!this.transport) {
+      this.callback.obj[this.callback.method](false, null, this.extra);
+      HTTP.goNext();
+      return;
+    }
+
+    this.transport(this.action, this.output, this.method, (success, data) => {
+      this.callback.obj[this.callback.method](success, data, this.extra);
+      HTTP.goNext();
+    });
+  }
+}
+
+module.exports = {
+  HTTP,
+};

--- a/packages/core-js/src/lang.js
+++ b/packages/core-js/src/lang.js
@@ -1,0 +1,126 @@
+const FEString = require('./feString');
+const FEDate = require('./feDate');
+const FENumber = require('./feNumber');
+
+/**
+ * Runtime JS mirror for Lot A target Lang (core formatting logic, no globals).
+ */
+class Lang {
+  static varName = 'langText';
+
+  static dig(obj, path) {
+    return path.split('.').reduce((cur, part) => (cur == null ? undefined : cur[part]), obj);
+  }
+
+  static fv(path, obj, langText) {
+    const base = Lang.dig(langText, path);
+    if (base !== undefined) return FEString.formatVars(base, obj);
+    return `[ERR] ${path}`;
+  }
+
+  static formatDateObject(obj, format, langText) {
+    obj.A = Lang.dig(langText, `date.day_short.${obj.b}`);
+    obj.a = Lang.dig(langText, `date.day.${obj.b}`);
+    obj.M = Lang.dig(langText, `date.month_short.${obj.n}`);
+    obj.m = Lang.dig(langText, `date.month.${obj.n}`);
+
+    const base = format !== undefined ? Lang.dig(langText, `date.format_${format}`) : undefined;
+    return base !== undefined
+      ? FEString.formatVars(base, obj)
+      : FEString.formatVars('$Y-$N-$D $H:$I:$S', obj);
+  }
+
+  static formatDate(date, format, langText) {
+    return Lang.formatDateObject(FEDate.getCompleteObject(date), format, langText);
+  }
+
+  static formatDateString(date, format, langText) {
+    return Lang.formatDate(FEDate.newFromString(date), format, langText);
+  }
+
+  static formatDateTime(t, format, langText) {
+    return Lang.formatDate(FEDate.newFromTime(t), format, langText);
+  }
+
+  static formatDuration(dur, format, langText) {
+    dur = Math.round(dur);
+    const obj = {
+      m: dur % 1000,
+      s: Math.floor(dur / 1000) % 60,
+      i: Math.floor(dur / 60000) % 60,
+      h: Math.floor(dur / 3600000),
+    };
+
+    const f = format === undefined ? 'default' : format;
+    if (obj.h > 0) return FEString.formatVars(Lang.dig(langText, `duration.format_${f}.h`), obj);
+    if (obj.i > 0) return FEString.formatVars(Lang.dig(langText, `duration.format_${f}.i`), obj);
+    if (obj.s > 0) return FEString.formatVars(Lang.dig(langText, `duration.format_${f}.s`), obj);
+    return FEString.formatVars(Lang.dig(langText, `duration.format_${f}.m`), obj);
+  }
+
+  static displayScoreType(score, ty, userMng) {
+    switch (ty) {
+      case 'millisecond': {
+        const ms = score % 1000;
+        const s = Math.floor(score / 1000) % 60;
+        const m = Math.floor(score / 60000);
+        return `${m > 0 ? `${m}'` : ''}${m > 0 ? FENumber.toStringL(s, 2) : s}"${FENumber.toStringL(ms, 3)}`;
+      }
+      case 'xp': {
+        const l = userMng.xpToLevel(score);
+        const c = Math.floor(userMng.xpLevelCompletionRate(score) * 100);
+        return `Niv. ${l}, ${FENumber.toStringL(c, 2)}%`;
+      }
+      case 'rate':
+        return `${Math.round(score * 100) / 100}%`;
+      case 'ptmb2':
+        return score < 100 ? `${score + 1}%` : `${Math.floor(score / 100)}, ${(score % 100) + 1}%`;
+      default:
+        return score;
+    }
+  }
+
+  static card2ord(p, langText) {
+    switch (Number(p)) {
+      case 1:
+        return `${p}${langText.ordinal.first}`;
+      case 2:
+        return `${p}${langText.ordinal.second}`;
+      case 3:
+        return `${p}${langText.ordinal.third}`;
+      case 4:
+        return `${p}${langText.ordinal.fourth}`;
+      case 5:
+        return `${p}${langText.ordinal.fifth}`;
+      default:
+        return `${p}${langText.ordinal.def}`;
+    }
+  }
+
+  static country(co, langText) {
+    const r = Lang.dig(langText, `countries.${co}.name`);
+    return r === undefined ? 'Inconnu' : r;
+  }
+
+  static region(co, rg, langText) {
+    const r = Lang.dig(langText, `countries.${co}.region.${rg}`);
+    return r === undefined ? 'Inconnu' : r;
+  }
+
+  static sign(fs, langText) {
+    return langText.sign[Number(fs)];
+  }
+
+  static gameName(discName, langText) {
+    const r = Lang.dig(langText, `disc_to_game.${discName}`);
+    return r === undefined ? discName : r;
+  }
+
+  static getTipDoc(id, langText) {
+    return Lang.dig(langText, `tip_doc.${id}`);
+  }
+}
+
+module.exports = {
+  Lang,
+};

--- a/packages/core-js/src/md5.js
+++ b/packages/core-js/src/md5.js
@@ -1,0 +1,12 @@
+const crypto = require('node:crypto');
+
+/**
+ * Runtime JS mirror for Lot A target MD5.
+ */
+function encode(str) {
+  return crypto.createHash('md5').update(str, 'utf8').digest('hex');
+}
+
+module.exports = {
+  encode,
+};

--- a/packages/core-js/src/mvpShowcase.js
+++ b/packages/core-js/src/mvpShowcase.js
@@ -1,0 +1,35 @@
+const { formatVars } = require('./feString');
+const { toRGBObj } = require('./feColor');
+const { StatusMng } = require('./statusMng');
+const { ClassLoader } = require('./classLoader');
+
+function buildMvpShowcase() {
+  const greeting = formatVars('Salut $0, build $1', { 0: 'Frutiparc', 1: 'Haxe/Node' });
+
+  const color = toRGBObj(0xff8800);
+
+  const parsedStatus = StatusMng.analyseStr('10a0');
+
+  const loader = new ClassLoader({ libPath: ['core.swf', 'ui.swf'], baseUrl: 'https://assets.example/' });
+  const firstLoad = loader.start();
+  loader.onLoadComplete({ name: 'lib0' });
+
+  return {
+    version: 'mvp-haxe-node',
+    generatedAt: new Date().toISOString(),
+    modules: {
+      feString: greeting,
+      feColor: color,
+      statusMng: parsedStatus,
+      classLoader: {
+        firstUrl: firstLoad.url,
+        nextLibLoaded: loader.libLoaded,
+        state: loader.state,
+      },
+    },
+  };
+}
+
+module.exports = {
+  buildMvpShowcase,
+};

--- a/packages/core-js/src/pref.js
+++ b/packages/core-js/src/pref.js
@@ -1,0 +1,113 @@
+const FEString = require('./feString');
+const FENumber = require('./feNumber');
+const FEObject = require('./feObject');
+
+/**
+ * Runtime JS mirror for Lot A target Pref (core logic only, no HTTP side-effects).
+ */
+class Pref {
+  constructor() {
+    this.types = { b: 'bool', i: 'int', s: 'string' };
+    this.prefs = {};
+    this.prefsId = [];
+  }
+
+  onLoadPrefDef(success, data) {
+    if (!success) return;
+    let str = data.PrefDef;
+    while (str.length > 0) {
+      const id = FEString.decode62(str.substr(0, 2));
+      str = str.substr(2);
+
+      const t = this.types[str.substr(0, 1)];
+      str = str.substr(1);
+
+      const l1 = FEString.decode62(str.substr(0, 2));
+      const name = str.substr(2, l1);
+      str = str.substr(l1 + 2);
+
+      const l2 = FEString.decode62(str.substr(0, 2));
+      let defaultValue = str.substr(2, l2);
+      str = str.substr(l2 + 2);
+
+      defaultValue = this.convert(defaultValue, t);
+      this.prefs[name] = { type: t, default_value: defaultValue, value: defaultValue, id };
+      this.prefsId[id] = name;
+    }
+  }
+
+  useMyPref(str) {
+    while (str.length > 0) {
+      const id = FEString.decode62(str.substr(0, 2));
+      const l = FEString.decode62(str.substr(2, 2));
+      let value = str.substr(4, l);
+      str = str.substr(l + 4);
+
+      const name = this.prefsId[id];
+      const t = this.prefs[name].type;
+      value = this.convert(value, t);
+      if (value !== undefined) this.prefs[name].value = value;
+    }
+  }
+
+  getFormatedPref() {
+    let r = '';
+    for (const n in this.prefs) {
+      const o = this.prefs[n];
+      if (o.value !== o.default_value) {
+        let content;
+        switch (o.type) {
+          case 'bool':
+            content = o.value ? 'Y' : 'N';
+            break;
+          case 'int':
+            content = FENumber.encode62(o.value);
+            break;
+          case 'string':
+          default:
+            content = o.value;
+            break;
+        }
+        r += FENumber.encode62(o.id, 2);
+        r += `${FENumber.encode62(content.length, 2)}${content}`;
+      }
+    }
+    return r;
+  }
+
+  getPref(n) {
+    if (n === 'cache_length' && this.prefs[n].value === undefined) return 30;
+    return this.prefs[n].value;
+  }
+
+  setPref(n, v) {
+    this.prefs[n].value = v;
+  }
+
+  setFromCopy(nPrefs) {
+    for (const n in nPrefs) {
+      const u = nPrefs[n];
+      const o = this.prefs[u.name];
+      if (o === undefined) continue;
+      o.value = u.value;
+    }
+  }
+
+  getACopy() {
+    return FEObject.recursiveClone(this.prefs);
+  }
+
+  convert(value, t) {
+    if (t === 'int') {
+      value = FEString.decode62(value);
+      if (Number.isNaN(value)) value = undefined;
+    } else if (t === 'bool') {
+      value = value === 'Y';
+    }
+    return value;
+  }
+}
+
+module.exports = {
+  Pref,
+};

--- a/packages/core-js/src/runDate.js
+++ b/packages/core-js/src/runDate.js
@@ -1,0 +1,60 @@
+const FEDate = require('./feDate');
+
+/**
+ * Runtime JS mirror for Lot A target RunDate.
+ */
+class RunDate {
+  constructor() {
+    this.ref = undefined;
+    this.refLocal = undefined;
+    this.diff = 0;
+  }
+
+  setFromString(str) {
+    this.refLocal = new Date();
+    this.ref = FEDate.newFromString(str);
+    this.diff = this.ref.getTime() - this.refLocal.getTime();
+  }
+
+  getTime() {
+    const d = new Date();
+    if (this.ref !== undefined) return d.getTime() + this.diff;
+    return d.getTime();
+  }
+
+  getDateObject() {
+    const d = new Date();
+    if (this.ref !== undefined) d.setTime(d.getTime() + this.diff);
+    return d;
+  }
+
+  getObject() {
+    return FEDate.getObject(this.getDateObject());
+  }
+
+  getCompleteObject() {
+    return FEDate.getCompleteObject(this.getDateObject());
+  }
+
+  toString() {
+    return this.getDateObject().toString();
+  }
+
+  toFormat(format, formatter) {
+    return formatter(this.getCompleteObject(), format);
+  }
+
+  getCurrentFSign() {
+    const t = this.getTime() / 1000;
+    return {
+      sign: Math.floor(((t - 345600) / 604800) % 10),
+      signb: Math.floor((t / 3600) % 10),
+      signCompletion: ((t - 345600) / 604800) % 1,
+      signbCompletion: (t / 3600) % 1,
+    };
+  }
+}
+
+module.exports = {
+  RunDate,
+};

--- a/packages/core-js/src/slot.js
+++ b/packages/core-js/src/slot.js
@@ -1,0 +1,167 @@
+/**
+ * Runtime JS mirror for Lot A follow-up Slot.
+ */
+class Slot {
+  static depths = {
+    boxList: {
+      start: 0,
+      dst: 1,
+      max: 100,
+    },
+  };
+
+  constructor() {
+    this.slotList = undefined;
+    this.arr = [];
+    this.nbBox = 0;
+    this.flActive = false;
+    this.baseDepth = 0;
+    this.depth = -1;
+    this.activeBox = null;
+    this.title = undefined;
+    this.flWarning = false;
+    this.flDesktopable = false;
+    this.flClose = false;
+  }
+
+  init(slotList, baseDepth, flGo = false) {
+    this.arr = [];
+    this.slotList = slotList;
+    this.baseDepth = baseDepth;
+
+    if (flGo) this.slotList.activate(this);
+  }
+
+  setDepth(baseDepth) {
+    this.baseDepth = baseDepth;
+    this.cleanDepths();
+  }
+
+  addBox(box) {
+    const d = this.getNextDepth();
+    this.arr[d] = box;
+    this.nbBox += 1;
+    box.init(this, this.baseDepth + Slot.depths.boxList.start + Slot.depths.boxList.dst * d);
+    this.activate(box);
+    this.onBoxListChanged();
+  }
+
+  rmBox(box) {
+    const id = this.arr.indexOf(box);
+    if (id > -1) {
+      this.arr[id] = undefined;
+      this.nbBox -= 1;
+      this.onBoxListChanged();
+    }
+  }
+
+  getNextDepth() {
+    if (this.depth + 1 > (Slot.depths.boxList.max - Slot.depths.boxList.start)) {
+      this.cleanDepths();
+    }
+    this.depth += 1;
+    return this.depth;
+  }
+
+  cleanDepths() {
+    for (let i = 0; i < this.arr.length; i += 1) {
+      if (this.arr[i] === undefined) {
+        this.arr.splice(i, 1);
+        i -= 1;
+      } else {
+        this.arr[i].setDepth(this.baseDepth + Slot.depths.boxList.start + Slot.depths.boxList.dst * i);
+      }
+    }
+  }
+
+  putOnTop(box) {
+    const id = this.arr.indexOf(box);
+    if (id > -1) {
+      this.arr[id] = undefined;
+      const d = this.getNextDepth();
+      this.arr[d] = box;
+      box.setDepth(this.baseDepth + Slot.depths.boxList.start + Slot.depths.boxList.dst * d);
+    }
+  }
+
+  onBoxListChanged() {}
+
+  close() {
+    this.flClose = true;
+    this.slotList.rmSlot(this);
+  }
+
+  tryToClose() {
+    if (this.arr.length === 0) {
+      this.close();
+    } else {
+      for (let i = 0; i < this.arr.length; i += 1) {
+        if (this.arr[i] !== undefined) this.arr[i].tryToClose();
+      }
+    }
+  }
+
+  onActivate() {
+    this.flActive = true;
+
+    if (this.flWarning) this.onStopWarning();
+
+    for (let i = 0; i < this.arr.length; i += 1) {
+      if (this.arr[i] !== undefined) this.arr[i].onSlotActivate();
+    }
+  }
+
+  onDeactivate() {
+    this.flActive = false;
+    for (let i = 0; i < this.arr.length; i += 1) {
+      if (this.arr[i] !== undefined) this.arr[i].onSlotDeactivate();
+    }
+  }
+
+  activate(box) {
+    if (this.activeBox === box) return false;
+    if (this.activeBox !== null) this.activeBox.onDeactivate();
+
+    this.activeBox = box;
+    this.putOnTop(box);
+    this.activeBox.onActivate();
+    return true;
+  }
+
+  move(box, newSlot) {
+    this.rmBox(box);
+    newSlot.addBox(box);
+  }
+
+  setTitle(t) {
+    this.title = t;
+  }
+
+  warning() {
+    if (this.flActive) return false;
+    if (this.flWarning) return false;
+
+    this.onWarning();
+    return true;
+  }
+
+  onWarning() {
+    if (this.flWarning) return false;
+
+    this.flWarning = true;
+    return true;
+  }
+
+  onStopWarning() {
+    if (!this.flWarning) return false;
+
+    this.flWarning = false;
+    return true;
+  }
+
+  onStageResize() {}
+}
+
+module.exports = {
+  Slot,
+};

--- a/packages/core-js/src/slotBase.js
+++ b/packages/core-js/src/slotBase.js
@@ -1,0 +1,20 @@
+/**
+ * Transitional base class mirroring the minimal Slot init contract.
+ */
+class SlotBase {
+  constructor() {
+    this.lastInitSlotList = null;
+    this.lastInitDepth = null;
+    this.lastInitFlGo = null;
+  }
+
+  init(slotList, depth, flGo) {
+    this.lastInitSlotList = slotList;
+    this.lastInitDepth = depth;
+    this.lastInitFlGo = flGo;
+  }
+}
+
+module.exports = {
+  SlotBase,
+};

--- a/packages/core-js/src/slotList.js
+++ b/packages/core-js/src/slotList.js
@@ -1,0 +1,83 @@
+/**
+ * Runtime JS mirror for Lot A follow-up SlotList.
+ */
+class SlotList {
+  static depths = {
+    slotList: {
+      start: 0,
+      dst: 1,
+      max: 50,
+    },
+  };
+
+  constructor() {
+    this.arr = [];
+    this.depth = -1;
+    this.activeSlot = undefined;
+  }
+
+  init() {
+    this.arr = [];
+  }
+
+  addSlot(slot, flGo = false) {
+    const d = this.getNextDepth();
+    this.arr[d] = slot;
+    slot.init(this, SlotList.depths.slotList.start + SlotList.depths.slotList.dst * d, flGo);
+  }
+
+  rmSlot(slot) {
+    const id = this.arr.indexOf(slot);
+    if (id > -1) {
+      this.arr[id] = undefined;
+      if (this.activeSlot === slot) this.activeSlot = undefined;
+      return true;
+    }
+    return false;
+  }
+
+  getNextDepth() {
+    if (this.depth + 1 > (SlotList.depths.slotList.max - SlotList.depths.slotList.start)) {
+      this.cleanDepths();
+    }
+    this.depth += 1;
+    return this.depth;
+  }
+
+  cleanDepths() {
+    for (let i = 0; i < this.arr.length; i += 1) {
+      if (this.arr[i] === undefined) {
+        this.arr.splice(i, 1);
+        i -= 1;
+      } else {
+        this.arr[i].setDepth(SlotList.depths.slotList.start + SlotList.depths.slotList.dst * i);
+      }
+    }
+  }
+
+  putOnTop(slot) {
+    const id = this.arr.indexOf(slot);
+    if (id > -1) {
+      this.arr[id] = undefined;
+      const d = this.getNextDepth();
+      this.arr[d] = slot;
+      slot.setDepth(SlotList.depths.slotList.start + SlotList.depths.slotList.dst * d);
+    }
+  }
+
+  activate(slot) {
+    if (slot === undefined) return false;
+    if (this.activeSlot === slot) return false;
+    if (slot.flClose) return false;
+
+    if (this.activeSlot !== undefined) this.activeSlot.onDeactivate();
+
+    this.activeSlot = slot;
+    this.activeSlot.onActivate();
+    return true;
+  }
+}
+
+module.exports = {
+  SlotList,
+};

--- a/packages/core-js/src/statusMng.js
+++ b/packages/core-js/src/statusMng.js
@@ -1,0 +1,88 @@
+const { decode62 } = require('./feString');
+const { encode62 } = require('./feNumber');
+
+/**
+ * Runtime JS mirror for Lot A follow-up StatusMng.
+ */
+class StatusMng {
+  static externalList = [undefined, 'eat', 'work', 'zzz', 'phone', 'away'];
+
+  static internalList = [undefined, 'forum', 'bkiwi', 'mb2', 'swapou2', 'snake3', 'bandas', 'grapiz', 'kaluga', 'miniwave'];
+
+  static analyseStr(str) {
+    let iExt = decode62(str.substr(0, 1));
+    iExt = Number.isNaN(iExt) ? 0 : iExt;
+
+    let iInt = decode62(str.substr(1, 2));
+    iInt = Number.isNaN(iInt) ? 0 : iInt;
+
+    let iEmote = decode62(str.substr(3, 1));
+    iEmote = Number.isNaN(iEmote) ? 0 : iEmote;
+
+    return {
+      external: StatusMng.externalList[iExt],
+      internal: StatusMng.internalList[iInt],
+      emote: iEmote,
+    };
+  }
+
+  constructor() {
+    this.external = 0;
+    this.internal = 0;
+    this.emote = 0;
+    this.cnx = undefined;
+    this.last = undefined;
+  }
+
+  setExternal(name) {
+    this.external = 0;
+    for (let i = 0; i < StatusMng.externalList.length; i += 1) {
+      if (StatusMng.externalList[i] === name) {
+        this.external = i;
+        break;
+      }
+    }
+    this.send();
+  }
+
+  setInternal(name) {
+    const idx = StatusMng.internalList.indexOf(name);
+    this.internal = idx < 0 ? 0 : idx;
+    this.send();
+  }
+
+  unsetInternal(name) {
+    const idx = StatusMng.internalList.indexOf(name);
+    if (this.internal === idx) {
+      this.internal = 0;
+      this.send();
+    }
+  }
+
+  setEmote(eId) {
+    const parsed = Number(eId);
+    if (Number.isNaN(parsed)) return;
+
+    this.emote = parsed;
+    this.send();
+  }
+
+  setCnx(cnx) {
+    this.cnx = cnx;
+  }
+
+  send() {
+    const str = encode62(this.external, 1) + encode62(this.internal, 2) + encode62(this.emote, 0);
+    if (str === this.last) return false;
+
+    if (this.cnx && typeof this.cnx.cmd === 'function') {
+      this.cnx.cmd('status', { s: str });
+    }
+    this.last = str;
+    return true;
+  }
+}
+
+module.exports = {
+  StatusMng,
+};

--- a/packages/core-js/src/tab.js
+++ b/packages/core-js/src/tab.js
@@ -1,0 +1,28 @@
+const { Slot } = require('./slot');
+
+/**
+ * Runtime JS mirror for Tab module.
+ */
+class Tab extends Slot {
+  init(slotList, depth, flGo = false) {
+    super.init(slotList, depth, flGo);
+  }
+
+  addBox(box) {
+    if (this.nbBox === 0) {
+      super.addBox(box);
+      return true;
+    }
+    return false;
+  }
+
+  rmBox(box) {
+    super.rmBox(box);
+    this.cleanDepths();
+    if (this.nbBox === 0) this.close();
+  }
+}
+
+module.exports = {
+  Tab,
+};

--- a/packages/core-js/src/userListMng.js
+++ b/packages/core-js/src/userListMng.js
@@ -1,0 +1,153 @@
+const { UserMng } = require('./userMng');
+
+/**
+ * Runtime JS mirror for Lot A follow-up UserListMng.
+ */
+class UserListMng {
+  constructor(userMngClass = UserMng) {
+    this.list = {};
+    this.arr = [];
+    this.length = 0;
+    this.listenerList = [];
+    this.userMngClass = userMngClass;
+  }
+
+  addUser(u, infoBasic, flMode = false, callOnChange = true) {
+    const key = String(u);
+
+    if (this.list[key] === undefined) {
+      this.length += 1;
+      const UserClass = this.userMngClass;
+      const user = new UserClass(key, infoBasic, flMode);
+      this.list[key] = user;
+      this.arr.push(user);
+    }
+
+    if (callOnChange) this.onChange();
+  }
+
+  rmUser(u, callOnChange = true) {
+    const key = String(u);
+    const user = this.list[key];
+    let removed = false;
+
+    if (user !== undefined) {
+      const idx = this.arr.indexOf(user);
+      if (idx >= 0) {
+        this.arr.splice(idx, 1);
+        removed = true;
+      }
+      this.length -= 1;
+      if (typeof user.onDelete === 'function') user.onDelete();
+      delete this.list[key];
+    }
+
+    if (callOnChange) this.onChange();
+    return removed;
+  }
+
+  rmAll() {
+    for (let i = 0; i < this.arr.length; i += 1) {
+      if (typeof this.arr[i].onDelete === 'function') this.arr[i].onDelete();
+    }
+    this.list = {};
+    this.arr = [];
+    this.length = 0;
+  }
+
+  defineMc(u, mc) {
+    const key = String(u);
+    if (!key.length || this.list[key] === undefined) return;
+    this.list[key].setMc(mc);
+  }
+
+  undefineMc(u, mc) {
+    const key = String(u);
+    if (!key.length || this.list[key] === undefined) return;
+    this.list[key].unsetMc(mc);
+  }
+
+  onChange() {
+    this.arr.sort((a, b) => a.sortString.localeCompare(b.sortString));
+    this.sendToAllListeners();
+  }
+
+  onUserAction(u, act) {
+    const key = String(u);
+    if (!key.length || this.list[key] === undefined) return;
+    this.list[key].onAction(act);
+  }
+
+  wantList(obj, method, start, length) {
+    let listener = this.listenerList.find((entry) => entry.obj === obj);
+    if (listener === undefined) {
+      listener = { obj, method, start, length };
+      this.listenerList.push(listener);
+    } else {
+      listener.method = method;
+      listener.start = start;
+      listener.length = length;
+    }
+
+    this.sendToListener(listener);
+  }
+
+  noMoreList(obj) {
+    const idx = this.listenerList.findIndex((entry) => entry.obj === obj);
+    if (idx > -1) {
+      this.listenerList.splice(idx, 1);
+      return true;
+    }
+    return false;
+  }
+
+  sendToAllListeners() {
+    for (let i = 0; i < this.listenerList.length; i += 1) {
+      this.sendToListener(this.listenerList[i]);
+    }
+  }
+
+  sendToListener(listener) {
+    const users = this.getPartAttrib(listener.start, listener.length, 'u');
+    listener.obj[listener.method](users, this.length);
+  }
+
+  isInList(user) {
+    return this.list[String(user)] !== undefined;
+  }
+
+  getRealUserName(user) {
+    const asked = String(user);
+    const lower = asked.toLowerCase();
+    for (let i = 0; i < this.arr.length; i += 1) {
+      if (String(this.arr[i].u).toLowerCase() === lower) return this.arr[i].u;
+    }
+    return asked;
+  }
+
+  modePresent() {
+    for (let i = 0; i < this.arr.length; i += 1) {
+      if (this.arr[i].flMode) return true;
+    }
+    return false;
+  }
+
+  isMode(user) {
+    const entry = this.list[String(user)];
+    return entry !== undefined && entry.flMode === true;
+  }
+
+  getUserArray() {
+    return this.getPartAttrib(0, this.length, 'u');
+  }
+
+  getPartAttrib(start, length, attr) {
+    const s = Math.max(0, Number(start) || 0);
+    const l = Math.max(0, Number(length) || 0);
+    return this.arr.slice(s, s + l).map((item) => item[attr]);
+  }
+}
+
+module.exports = {
+  UserListMng,
+};

--- a/packages/core-js/src/userMng.js
+++ b/packages/core-js/src/userMng.js
@@ -1,0 +1,136 @@
+const { Lang } = require('./lang');
+
+/**
+ * Runtime JS mirror for Lot A target UserMng (core logic subset).
+ */
+class UserMng {
+  static xpToLevel(xp) {
+    xp = Math.max(0, xp);
+    return Math.floor(Math.sqrt(xp / 10000) + 1);
+  }
+
+  static levelToXp(level) {
+    level = Math.max(1, level);
+    return ((level - 1) ** 2) * 10000;
+  }
+
+  static xpLevelCompletionRate(xp) {
+    const level = UserMng.xpToLevel(xp);
+    const xpOk = xp - UserMng.levelToXp(level);
+    const between = UserMng.levelToXp(level + 1) - UserMng.levelToXp(level);
+    return xpOk / between;
+  }
+
+  static birthdayToAge(bd, now = new Date()) {
+    if (bd === undefined || bd === '0000-00-00' || bd.length < 10) return 0;
+    const y = Number(bd.substr(0, 4));
+    const m = Number(bd.substr(5, 2));
+    const d = Number(bd.substr(8, 2));
+
+    const ly = now.getFullYear();
+    const lm = now.getMonth() + 1;
+    const ld = now.getDate();
+
+    if (lm > m || (lm === m && ld >= d)) return ly - y;
+    return ly - y - 1;
+  }
+
+  static birthdayToMonthAge(bd, now = new Date()) {
+    if (bd === undefined || bd === '0000-00-00 00:00:00' || bd.length < 19) return 0;
+    const y = Number(bd.substr(0, 4));
+    const m = Number(bd.substr(5, 2));
+    const d = Number(bd.substr(8, 2));
+
+    const ly = now.getFullYear();
+    const lm = now.getMonth() + 1;
+    const ld = now.getDate();
+
+    return (ly - y) * 12 + (lm - m) - (ld < d ? 1 : 0);
+  }
+
+  static formatInfoBasic(node, now, langText) {
+    return {
+      xpLevel: UserMng.xpToLevel(Number(node.attributes.x)),
+      xpCompletionRate: UserMng.xpLevelCompletionRate(Number(node.attributes.x)),
+      nickname: node.attributes.u,
+      gender: node.attributes.sx,
+      age: UserMng.birthdayToAge(node.attributes.bd, now),
+      birthday: node.attributes.bd,
+      country: Lang.country(node.attributes.co, langText),
+      countryCode: node.attributes.co,
+      region: Lang.region(node.attributes.co, node.attributes.rg, langText),
+    };
+  }
+
+  constructor(u, iB = {}, flMode = false) {
+    this.u = u;
+    this.flMode = flMode;
+    this.mcList = [];
+
+    this.updateSortString();
+
+    this.infoBasic = {
+      status: { internal: undefined, external: undefined, emote: undefined },
+      fbouille: '000503000000111010',
+      presence: 0,
+      xpLevel: 1,
+      xpCompletionRate: 0,
+      nickname: u,
+      gender: 'M',
+      age: undefined,
+      birthday: '',
+      country: '',
+      region: '',
+      flMute: false,
+    };
+
+    Object.assign(this.infoBasic, iB);
+  }
+
+  setMc(mc) {
+    if (mc === undefined) return;
+    if (!this.mcList.includes(mc)) this.mcList.push(mc);
+    if (this.infoBasic !== undefined && typeof mc.onInfoBasic === 'function') {
+      mc.onInfoBasic(this.getInfoBasic());
+    }
+  }
+
+  unsetMc(mc) {
+    this.mcList = this.mcList.filter((m) => m !== mc);
+  }
+
+  onAction(act) {
+    for (let i = 0; i < this.mcList.length; i += 1) {
+      if (typeof this.mcList[i].onAction === 'function') this.mcList[i].onAction(act);
+    }
+  }
+
+  onStatusObj(obj) {
+    if (obj === undefined) return;
+    Object.assign(this.infoBasic, obj);
+
+    for (let i = 0; i < this.mcList.length; i += 1) {
+      if (typeof this.mcList[i].onInfoBasic === 'function') this.mcList[i].onInfoBasic(obj);
+    }
+  }
+
+  onDelete() {
+    this.mcList = [];
+  }
+
+  setInfoBasic(obj) {
+    Object.assign(this.infoBasic, obj);
+  }
+
+  getInfoBasic() {
+    return this.infoBasic;
+  }
+
+  updateSortString() {
+    this.sortString = `${this.flMode ? '0' : '1'}${this.u.toLowerCase()}`;
+  }
+}
+
+module.exports = {
+  UserMng,
+};

--- a/packages/core-js/src/winBox.js
+++ b/packages/core-js/src/winBox.js
@@ -1,0 +1,95 @@
+/**
+ * Runtime JS mirror for Lot A follow-up WinBox.
+ */
+class WinBox {
+  constructor() {
+    this.initialized = false;
+    this.slot = undefined;
+    this.depth = undefined;
+    this.flShow = false;
+    this.flActive = false;
+    this.wasShow = false;
+    this.title = undefined;
+    this.flClosed = false;
+    this.window = undefined;
+    this.mode = undefined;
+  }
+
+  preInit() {
+    if (this.title === undefined) this.title = '';
+  }
+
+  init(slot, depth) {
+    const rs = !this.initialized;
+    if (rs) this.preInit();
+
+    this.initialized = true;
+    this.slot = slot;
+    this.depth = depth;
+    this.flShow = true;
+
+    return rs;
+  }
+
+  setDepth(depth) {
+    this.depth = depth;
+  }
+
+  close() {
+    this.slot.rmBox(this);
+    this.flClosed = true;
+  }
+
+  tryToClose() {
+    this.close();
+  }
+
+  hide() {
+    this.flShow = false;
+  }
+
+  show() {
+    this.flShow = true;
+  }
+
+  onActivate() {
+    this.flActive = true;
+  }
+
+  onDeactivate() {
+    this.flActive = false;
+  }
+
+  onSlotActivate() {
+    if (this.wasShow) this.show();
+    this.wasShow = false;
+  }
+
+  onSlotDeactivate() {
+    if (this.flShow) {
+      this.wasShow = true;
+      this.hide();
+    } else {
+      this.wasShow = false;
+    }
+  }
+
+  activate() {
+    this.slot.activate(this);
+  }
+
+  move(newSlot) {
+    if (this.slot === newSlot) return false;
+
+    this.slot.move(this, newSlot);
+    return true;
+  }
+
+  setTitle(t) {
+    this.title = t;
+  }
+}
+
+module.exports = {
+  WinBox,
+};

--- a/packages/core-js/src/winStandard.js
+++ b/packages/core-js/src/winStandard.js
@@ -1,0 +1,127 @@
+const { Window } = require('./window');
+
+/**
+ * Runtime JS mirror for pragmatic WinStandard migration subset.
+ */
+class WinStandard extends Window {
+  static env = {
+    frameMode: false,
+    mcw: 800,
+    mch: 600,
+    cornerX: 0,
+    cornerY: 0,
+    tmod: 1,
+  };
+
+  constructor() {
+    super();
+    this.pos = { x: 0, y: 0, w: 0, h: 0 };
+    this.minimum = { w: 0, h: 0 };
+    this.tab = { w: 0, h: 0 };
+    this.box = { mode: 'desktop' };
+    this.gel = 0;
+    this.flResizable = undefined;
+    this.flMoveAnim = undefined;
+    this.flInterface = undefined;
+    this.title = undefined;
+    this.xScale = 100;
+    this.yScale = 100;
+    this.xPos = 0;
+    this.yPos = 0;
+  }
+
+  init() {
+    if (this.flInterface === undefined) this.flInterface = true;
+    super.init();
+    if (this.flResizable === undefined) this.flResizable = true;
+    if (this.flMoveAnim === undefined) this.flMoveAnim = true;
+  }
+
+  update() {
+    this.updateSize();
+    this.updatePos();
+  }
+
+  updatePos() {
+    if (this.box.mode === 'desktop') this.updateDeskPos();
+    else if (this.box.mode === 'tab') this.updateTabPos();
+  }
+
+  updateSize() {
+    if (this.box.mode === 'desktop') this.updateDeskSize();
+    else if (this.box.mode === 'tab') this.updateTabSize();
+  }
+
+  updateDeskPos() {
+    this.recal();
+    this.moveToPos();
+  }
+
+  moveToPos() {
+    this.xPos = this.pos.x;
+    this.yPos = this.pos.y;
+  }
+
+  updateDeskSize() {
+    this.minimum.w = Math.max(0, this.minimum.w);
+    this.minimum.h = Math.max(0, this.minimum.h);
+  }
+
+  updateTabPos() {
+    this.xPos = WinStandard.env.cornerX;
+    this.yPos = WinStandard.env.cornerY;
+  }
+
+  updateTabSize() {
+    this.tab.w = WinStandard.env.mcw - WinStandard.env.cornerX;
+    this.tab.h = WinStandard.env.mch - WinStandard.env.cornerY;
+  }
+
+  recal() {
+    if (WinStandard.env.frameMode) return false;
+
+    const oldPos = { ...this.pos };
+
+    this.pos.w = Math.max(Math.min(WinStandard.env.mcw - WinStandard.env.cornerX, this.pos.w), this.minimum.w);
+    this.pos.h = Math.max(Math.min(WinStandard.env.mch - WinStandard.env.cornerY, this.pos.h), this.minimum.h);
+    this.pos.x = Math.max(Math.min(this.pos.x, WinStandard.env.mcw - this.pos.w), WinStandard.env.cornerX);
+    this.pos.y = Math.max(Math.min(this.pos.y, WinStandard.env.mch - this.pos.h), WinStandard.env.cornerY);
+
+    return oldPos.x !== this.pos.x || oldPos.y !== this.pos.y || oldPos.w !== this.pos.w || oldPos.h !== this.pos.h;
+  }
+
+  resize(w, h) {
+    this.pos.w = w;
+    this.pos.h = h;
+    this.recal();
+    this.update();
+  }
+
+  onChangeMode() {
+    if (this.box.mode === 'desktop') this.initDesktopMode();
+    else this.initTabMode();
+    this.update();
+  }
+
+  initDesktopMode() {}
+
+  initTabMode() {}
+
+  onStageResize() {
+    this.update();
+  }
+
+  setTitle(title) {
+    this.title = title;
+  }
+
+  gelatine() {
+    this.gel = (this.gel + WinStandard.env.tmod * 10) % 628;
+    this.xScale = 100 + Math.cos(this.gel / 100) * 4;
+    this.yScale = 100 + Math.sin(this.gel / 100) * 4;
+  }
+}
+
+module.exports = {
+  WinStandard,
+};

--- a/packages/core-js/src/window.js
+++ b/packages/core-js/src/window.js
@@ -1,0 +1,13 @@
+/**
+ * Runtime JS mirror for Lot A target Window.
+ * Mirrors the minimal API ported in Haxe.
+ */
+class Window {
+  constructor() {}
+
+  init() {}
+}
+
+module.exports = {
+  Window,
+};

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const { WebSocketServer } = require('ws');
 const path = require('path');
+const { buildMvpShowcase } = require('./packages/core-js/src/mvpShowcase');
 
 const app = express();
 // The original game expects the HTTP server to run on port 8888.
@@ -23,6 +24,10 @@ app.get('/ff/mv', (req, res) => {
 
 app.get('/ff/cp', (req, res) => {
   res.sendFile(path.join(__dirname, 'examples', 'ff_cp.json'));
+});
+
+app.get('/api/mvp/showcase', (req, res) => {
+  res.json(buildMvpShowcase());
 });
 
 const server = app.listen(port, () => {

--- a/tests/migration/cbee.spec.js
+++ b/tests/migration/cbee.spec.js
@@ -1,0 +1,78 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { CBee } = require('../../packages/core-js/src/cbee');
+
+test('CBee connect/send/cmd lifecycle', () => {
+  const cbee = new CBee({ cmdList: { ping: 'p', onconnect: 'onconnect', onclose: 'onclose' } });
+
+  cbee.connect('localhost', 9000);
+  assert.equal(cbee.connected, false);
+  assert.equal(cbee.send({}), false);
+
+  cbee.onConnect(true);
+  assert.equal(cbee.connected, true);
+  assert.equal(cbee.cnxNb, 1);
+
+  assert.equal(cbee.cmd('ping', { a: 1 }), true);
+  assert.equal(cbee.sentLog.length, 1);
+  assert.deepEqual(cbee.sentLog[0], { nodeName: 'p', attributes: { a: 1 } });
+
+  cbee.onClose();
+  assert.equal(cbee.connected, false);
+});
+
+test('CBee command listeners and specific listeners', () => {
+  const cbee = new CBee({ cmdList: { msg: 'm', onconnect: 'onconnect', onclose: 'onclose' } });
+
+  const events = [];
+  const obj = {
+    onMsg(node) { events.push(['all', node.attributes.kind]); },
+    onSpec(node) { events.push(['spec', node.attributes.kind]); },
+  };
+
+  cbee.addListener('msg', obj, 'onMsg');
+  cbee.addListener('msg', obj, 'onSpec', 'kind', 'chat');
+
+  cbee.onXML({ nodeName: 'm', attributes: { kind: 'chat' } });
+  cbee.onXML({ nodeName: 'm', attributes: { kind: 'sys' } });
+
+  assert.deepEqual(events, [
+    ['all', 'chat'],
+    ['spec', 'chat'],
+    ['all', 'sys'],
+  ]);
+
+  cbee.removeListenerCmdObj('msg', obj, 'kind', 'chat');
+  cbee.onXML({ nodeName: 'm', attributes: { kind: 'chat' } });
+  assert.deepEqual(events.at(-1), ['all', 'chat']);
+
+  cbee.removeListenerCmd('msg');
+  cbee.onXML({ nodeName: 'm', attributes: { kind: 'sys' } });
+  assert.deepEqual(events.at(-1), ['all', 'chat']);
+});
+
+test('CBee global listener receives events', () => {
+  const cbee = new CBee({ cmdList: { onconnect: 'onconnect', onclose: 'onclose' } });
+  const events = [];
+
+  cbee.setGlobalListener({
+    obj: {
+      onEvt(port, name, data) {
+        events.push([port, name, data && data.nodeName]);
+      },
+    },
+    method: 'onEvt',
+  });
+
+  cbee.connect('h', 1000);
+  cbee.onConnect(false);
+  cbee.onXML({ nodeName: 'foo', attributes: {} });
+  cbee.onClose();
+
+  assert.deepEqual(events, [
+    [1000, 'onConnect', false],
+    [1000, 'onXML', 'foo'],
+    [1000, 'onClose', undefined],
+  ]);
+});

--- a/tests/migration/cbeeLc.spec.js
+++ b/tests/migration/cbeeLc.spec.js
@@ -1,0 +1,27 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { CBeeLC } = require('../../packages/core-js/src/cbeeLc');
+
+test('CBeeLC delegates send and cmd to cbee instance', () => {
+  const calls = [];
+  const cbee = {
+    send(payload) {
+      calls.push(['send', payload]);
+      return `sent:${payload}`;
+    },
+    cmd(a, b, c) {
+      calls.push(['cmd', a, b, c]);
+      return `${a}|${b}|${c}`;
+    },
+  };
+
+  const lc = new CBeeLC(cbee);
+
+  assert.equal(lc.send('hello'), 'sent:hello');
+  assert.equal(lc.cmd('A', 'B', 'C'), 'A|B|C');
+  assert.deepEqual(calls, [
+    ['send', 'hello'],
+    ['cmd', 'A', 'B', 'C'],
+  ]);
+});

--- a/tests/migration/cbeeLocal.spec.js
+++ b/tests/migration/cbeeLocal.spec.js
@@ -1,0 +1,100 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { CBeeLocal } = require('../../packages/core-js/src/cbeeLocal');
+
+test('CBeeLocal init binds manager and propagates status', () => {
+  const sent = [];
+  const manager = {
+    addListener(port) {
+      return { send(payload) { sent.push([port, payload]); }, cmd() {} };
+    },
+    getStatus() { return { connected: true, logged: false }; },
+    removeListener() {},
+  };
+
+  const cbl = new CBeeLocal({ port: 1001, cbeeManager: manager });
+  cbl.init();
+
+  assert.equal(cbl.initialized, true);
+  assert.equal(cbl.connected, true);
+
+  assert.equal(cbl.send('hello'), true);
+  assert.deepEqual(sent, [[1001, 'hello']]);
+});
+
+test('CBeeLocal listeners and specific listeners dispatch', () => {
+  const cbl = new CBeeLocal();
+  const events = [];
+  const obj = {
+    onAny(node) { events.push(['any', node.attributes.t]); },
+    onSpec(node) { events.push(['spec', node.attributes.t]); },
+  };
+
+  cbl.addListener('ident', obj, 'onAny');
+  cbl.addListener('ident', obj, 'onSpec', 't', 'chat');
+
+  cbl.onXML({ nodeName: 'ident', attributes: { t: 'chat' } });
+  cbl.onXML({ nodeName: 'ident', attributes: { t: 'sys' } });
+
+  assert.deepEqual(events, [
+    ['any', 'chat'],
+    ['spec', 'chat'],
+    ['any', 'sys'],
+  ]);
+
+  cbl.removeListenerCmdObj('ident', obj, 't', 'chat');
+  cbl.onXML({ nodeName: 'ident', attributes: { t: 'chat' } });
+  assert.deepEqual(events.at(-1), ['any', 'chat']);
+});
+
+test('CBeeLocal ident/login and close behavior', () => {
+  const removed = [];
+  const cbl = new CBeeLocal({
+    cbeeManager: { removeListener(port, obj) { removed.push([port, obj]); } },
+    port: 1234,
+  });
+
+  cbl.onIdent({ attributes: {} });
+  assert.equal(cbl.logged, true);
+
+  cbl.onIdent({ attributes: { k: 'ko' } });
+  assert.equal(cbl.logged, false);
+
+  cbl.close();
+  assert.equal(removed.length, 1);
+});
+
+test('CBeeLocal external mode init/send/cmd mirrors LocalConnection flow', () => {
+  const sent = [];
+  const makeConnection = () => ({
+    onStatus: null,
+    send(...args) {
+      sent.push(args);
+      if (typeof this.onStatus === 'function' && args[0] === 'fp_cbeeMng_SID42') this.onStatus({ level: 'status' });
+    },
+  });
+  const inbound = { connectedTo: null, connect(name) { this.connectedTo = name; } };
+
+  const cbl = new CBeeLocal({
+    port: 4321,
+    sid: 'SID42',
+    inboundConnection: inbound,
+    localConnectionFactory: makeConnection,
+  });
+
+  cbl.init();
+  assert.equal(typeof inbound.connectedTo, 'string');
+  assert.deepEqual(sent[0], ['fp_cbeeMng_SID42', 'addListener', 4321, inbound.connectedTo]);
+  assert.deepEqual(sent[1], ['fp_cbeeMng_SID42', 'getStatus', 4321, inbound.connectedTo]);
+
+  cbl.onStatus({ connected: true, logged: true });
+  assert.equal(cbl.connected, true);
+  assert.equal(cbl.logged, true);
+
+  assert.equal(cbl.send('payload'), true);
+  assert.deepEqual(sent.at(-1), ['fp_cbee_4321_SID42', 'send', 'payload']);
+
+  assert.equal(cbl.cmd('join', { x: 1 }, 'child'), true);
+  assert.deepEqual(sent.at(-1), ['fp_cbee_4321_SID42', 'cmd', 'join', { x: 1 }, 'child']);
+});

--- a/tests/migration/cbeeManager.spec.js
+++ b/tests/migration/cbeeManager.spec.js
@@ -1,0 +1,58 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { CBeeManager } = require('../../packages/core-js/src/cbeeManager');
+
+test('CBeeManager add/get/remove listener lifecycle', () => {
+  const manager = new CBeeManager({ host: 'srv' });
+
+  const listener = {
+    status: [],
+    onStatus(obj) { this.status.push(obj); },
+    onXML() {},
+  };
+
+  const lc = manager.addListener(1234, listener);
+  assert.ok(lc);
+  assert.equal(manager.cbeeCnx['1234'].listeners.length, 1);
+
+  const status = manager.getStatus(1234, listener);
+  assert.equal(status.connected, false);
+  assert.equal(listener.status.length, 1);
+
+  manager.removeListener(1234, listener, false);
+  assert.equal(manager.cbeeCnx['1234'].listeners.length, 0);
+
+  manager.removeListener(1234, listener, true);
+  assert.equal(manager.cbeeCnx['1234'], undefined);
+});
+
+test('CBeeManager onGlobalListener forwards and auto-closes idle', () => {
+  const manager = new CBeeManager({ host: 'srv' });
+  manager.addCnx(2345, false);
+
+  const events = [];
+  const listener = {
+    onXML(data) { events.push(['xml', data.nodeName]); },
+    onClose() { events.push(['close']); },
+  };
+
+  manager.addListener(2345, listener);
+  manager.onGlobalListener(2345, 'onXML', { nodeName: 'msg' });
+  assert.deepEqual(events.at(-1), ['xml', 'msg']);
+
+  manager.removeListener(2345, listener, false);
+  manager.onGlobalListener(2345, 'onClose');
+  assert.equal(manager.cbeeCnx['2345'], undefined);
+});
+
+test('CBeeManager checkAll removes timed out empty connections', () => {
+  let now = 1000;
+  const manager = new CBeeManager({ host: 'srv', cnxTimeout: 50, now: () => now });
+  manager.addCnx(3456, false);
+
+  now = 1100;
+  manager.checkAll();
+
+  assert.equal(manager.cbeeCnx['3456'], undefined);
+});

--- a/tests/migration/classLoader.spec.js
+++ b/tests/migration/classLoader.spec.js
@@ -1,0 +1,45 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { ClassLoader } = require('../../packages/core-js/src/classLoader');
+
+test('ClassLoader starts first load and chains until play', () => {
+  const calls = [];
+  const loader = {
+    listener: null,
+    addListener(l) { this.listener = l; },
+    loadClip(url, mc) { calls.push([url, mc.name, mc.depth]); },
+  };
+
+  let played = 0;
+  const cl = new ClassLoader({
+    loader,
+    libPath: ['a.swf', 'b.swf'],
+    baseUrl: 'https://cdn/',
+    onPlay() { played += 1; },
+  });
+
+  cl.start();
+  assert.equal(cl.state, 'stopped');
+  assert.deepEqual(calls[0], ['https://cdn/a.swf', 'lib0', 80]);
+
+  cl.onLoadComplete({ name: 'lib0' });
+  assert.equal(cl.libLoaded, 1);
+  assert.deepEqual(calls[1], ['https://cdn/b.swf', 'lib1', 81]);
+
+  cl.onLoadComplete({ name: 'lib1' });
+  assert.equal(cl.state, 'playing');
+  assert.equal(played, 1);
+});
+
+test('ClassLoader logs load events', () => {
+  const cl = new ClassLoader({ libPath: ['x.swf'] });
+
+  cl.onLoadStart({ name: 'lib0' });
+  cl.onLoadError({ name: 'lib0' }, '404');
+  cl.onLoadComplete({ name: 'lib0' });
+
+  assert.match(cl.logText, /loadStart\(lib0\)/);
+  assert.match(cl.logText, /loadError\(404\)/);
+  assert.match(cl.logText, /loadComplete\(lib0\)/);
+});

--- a/tests/migration/desktop.spec.js
+++ b/tests/migration/desktop.spec.js
@@ -1,0 +1,22 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { Desktop } = require('../../packages/core-js/src/desktop');
+
+test('Desktop initializes with empty iconList', () => {
+  const desktop = new Desktop();
+  assert.deepEqual(desktop.iconList, []);
+});
+
+test('Desktop.init forwards args to SlotBase and resets iconList', () => {
+  const desktop = new Desktop();
+  desktop.iconList.push('old-icon');
+
+  const slotList = ['a', 'b'];
+  desktop.init(slotList, 42, true);
+
+  assert.equal(desktop.lastInitSlotList, slotList);
+  assert.equal(desktop.lastInitDepth, 42);
+  assert.equal(desktop.lastInitFlGo, true);
+  assert.deepEqual(desktop.iconList, []);
+});

--- a/tests/migration/fFileMng.spec.js
+++ b/tests/migration/fFileMng.spec.js
@@ -1,0 +1,77 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { FFileMng } = require('../../packages/core-js/src/fFileMng');
+
+function linkSiblings(children) {
+  for (let i = 0; i < children.length - 1; i += 1) {
+    children[i].nextSibling = children[i + 1];
+  }
+  if (children.length) children[children.length - 1].nextSibling = null;
+  return children[0] || null;
+}
+
+function node(nodeName, attributes = {}, children = []) {
+  const n = {
+    nodeType: 1,
+    nodeName,
+    attributes,
+    firstChild: null,
+    nextSibling: null,
+    hasChildNodes() {
+      return this.firstChild !== null;
+    },
+  };
+  n.firstChild = linkSiblings(children);
+  return n;
+}
+
+function fileNode(uid, lines) {
+  return {
+    nodeType: 1,
+    nodeName: 'e',
+    attributes: { u: uid, t: 'mail', s: '42', d: '2024-01-01', a: 'rw' },
+    firstChild: { nodeValue: lines },
+    nextSibling: null,
+    hasChildNodes() { return true; },
+  };
+}
+
+test('onLoadTree parses folder IDs and tree structure', () => {
+  const mng = new FFileMng();
+
+  const childFolder = node('f', { u: 'inbox', n: 'Inbox', t: 'sys', p: 'tpl' });
+  const rootFolder = node('f', {
+    u: 'messages',
+    n: 'Messages',
+    t: 'sys',
+    p: 'tpl',
+    b: 'messages;inbox;outbox;blackbox;draftbox;disc;inv;contact;bin',
+  }, [childFolder]);
+
+  const ok = mng.onLoadTree(true, { lastChild: rootFolder });
+
+  assert.equal(ok, true);
+  assert.equal(mng.messages, 'messages');
+  assert.equal(mng.inbox, 'inbox');
+  assert.deepEqual(mng.tree.messages.childs, ['inbox']);
+  assert.equal(mng.tree.inbox.parent, 'messages');
+});
+
+test('analyseXml builds folder/file listing', () => {
+  const mng = new FFileMng();
+  mng.tree.messages = { name: 'Messages', type: 'sys', tpl: 'tpl', parent: undefined, childs: [] };
+  mng.tree.sub = { name: 'Sub', type: 'usr', tpl: 'tpl2', parent: 'messages', childs: [] };
+
+  const nestedFolder = node('f', { u: 'sub' }, [fileNode('f2', 'Nested\r\nFile')]);
+  const rootXml = node('f', { u: 'messages' }, [fileNode('f1', 'Hello\r\nWorld'), nestedFolder]);
+
+  const result = mng.analyseXml(rootXml);
+
+  assert.equal(result.uid, 'messages');
+  assert.equal(result.list.length, 2);
+  assert.equal(result.list[0].uid, 'f1');
+  assert.deepEqual(result.list[0].desc, ['Hello', 'World']);
+  assert.equal(result.list[1].uid, 'sub');
+  assert.equal(result.list[1].list[0].uid, 'f2');
+});

--- a/tests/migration/feColor.spec.js
+++ b/tests/migration/feColor.spec.js
@@ -1,0 +1,23 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { toRGBObj, toRGBInt } = require('../../packages/core-js/src/feColor');
+
+test('toRGBObj splits integer color into channels', () => {
+  assert.deepEqual(toRGBObj(0x112233), { r: 0x11, g: 0x22, b: 0x33 });
+  assert.deepEqual(toRGBObj(0x000000), { r: 0, g: 0, b: 0 });
+  assert.deepEqual(toRGBObj(0xffffff), { r: 255, g: 255, b: 255 });
+});
+
+test('toRGBInt combines channels into integer color', () => {
+  assert.equal(toRGBInt({ r: 0x11, g: 0x22, b: 0x33 }), 0x112233);
+  assert.equal(toRGBInt({ r: 0, g: 0, b: 0 }), 0);
+  assert.equal(toRGBInt({ r: 255, g: 255, b: 255 }), 0xffffff);
+});
+
+test('roundtrip is stable for sample values', () => {
+  const samples = [0, 1, 255, 0x123456, 0xffffff, 0xabc123];
+  for (const value of samples) {
+    assert.equal(toRGBInt(toRGBObj(value)), value);
+  }
+});

--- a/tests/migration/feDate.spec.js
+++ b/tests/migration/feDate.spec.js
@@ -1,0 +1,50 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const FEDate = require('../../packages/core-js/src/feDate');
+
+test('newFromString parses YYYY-MM-DD HH:II:SS', () => {
+  const d = FEDate.newFromString('2024-03-05 06:07:08');
+  assert.equal(d.getFullYear(), 2024);
+  assert.equal(d.getMonth(), 2);
+  assert.equal(d.getDate(), 5);
+  assert.equal(d.getHours(), 6);
+  assert.equal(d.getMinutes(), 7);
+  assert.equal(d.getSeconds(), 8);
+});
+
+test('newFromTime rebuilds a date from timestamp', () => {
+  const ts = 1710000000000;
+  const d = FEDate.newFromTime(ts);
+  assert.equal(d.getTime(), ts);
+});
+
+test('getObject returns zero-padded date fields', () => {
+  const d = new Date(2024, 0, 2, 3, 4, 5);
+  assert.deepEqual(FEDate.getObject(d), {
+    y: '2024',
+    m: '01',
+    d: '02',
+    h: '03',
+    i: '04',
+    s: '05',
+  });
+});
+
+test('getCompleteObject returns expanded fields', () => {
+  const d = new Date(2024, 0, 2, 3, 4, 5);
+  const obj = FEDate.getCompleteObject(d);
+
+  assert.equal(obj.Y, '2024');
+  assert.equal(obj.y, '24');
+  assert.equal(obj.n, '1');
+  assert.equal(obj.N, '01');
+  assert.equal(obj.d, '2');
+  assert.equal(obj.D, '02');
+  assert.equal(obj.h, '3');
+  assert.equal(obj.H, '03');
+  assert.equal(obj.i, '4');
+  assert.equal(obj.I, '04');
+  assert.equal(obj.s, '5');
+  assert.equal(obj.S, '05');
+});

--- a/tests/migration/feNumber.spec.js
+++ b/tests/migration/feNumber.spec.js
@@ -1,0 +1,31 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const FENumber = require('../../packages/core-js/src/feNumber');
+
+test('toColorObj splits RGB int', () => {
+  assert.deepEqual(FENumber.toColorObj(0x123456), { r: 0x12, g: 0x34, b: 0x56 });
+});
+
+test('toAlphaString follows legacy sequence', () => {
+  assert.equal(FENumber.toAlphaString(1), 'a');
+  assert.equal(FENumber.toAlphaString(26), 'z');
+  assert.equal(FENumber.toAlphaString(27), 'aa');
+  assert.equal(FENumber.toAlphaString(52), 'az');
+  assert.equal(FENumber.toAlphaString(53), 'ba');
+});
+
+test('encode62 and toStringL helpers', () => {
+  assert.equal(FENumber.encode62(0), '0');
+  assert.equal(FENumber.encode62(61), 'Z');
+  assert.equal(FENumber.encode62(62), '10');
+  assert.equal(FENumber.encode62(15, 3), '00f');
+  assert.equal(FENumber.toStringL(42, 5), '00042');
+  assert.equal(FENumber.toStringL(undefined, 3), '000');
+});
+
+test('modCol applies inc/coef with clamping', () => {
+  assert.equal(FENumber.modCol(0x112233, 10, 1), 0x1b2c3d);
+  assert.equal(FENumber.modCol(0xff0000, 0, 0.5), 0x800000);
+  assert.equal(FENumber.modCol(0x000000, -10, 1), 0x000000);
+});

--- a/tests/migration/feObject.spec.js
+++ b/tests/migration/feObject.spec.js
@@ -1,0 +1,35 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const FEObject = require('../../packages/core-js/src/feObject');
+
+test('clone performs shallow copy', () => {
+  const source = { a: 1, b: { c: 2 } };
+  const cloned = FEObject.clone(source);
+
+  assert.deepEqual(cloned, source);
+  assert.notEqual(cloned, source);
+  assert.equal(cloned.b, source.b);
+});
+
+test('recursiveClone performs deep copy', () => {
+  const source = { a: 1, b: { c: 2 } };
+  const cloned = FEObject.recursiveClone(source);
+
+  assert.deepEqual(cloned, source);
+  assert.notEqual(cloned, source);
+  assert.notEqual(cloned.b, source.b);
+});
+
+test('addObject fills missing fields and supports splash', () => {
+  const base = { a: 1 };
+  FEObject.addObject(base, { a: 2, b: 3 }, false);
+  assert.deepEqual(base, { a: 1, b: 3 });
+
+  FEObject.addObject(base, { a: 9 }, true);
+  assert.deepEqual(base, { a: 9, b: 3 });
+});
+
+test('toColNumber creates numeric color from rgb object', () => {
+  assert.equal(FEObject.toColNumber({ r: 0x11, g: 0x22, b: 0x33 }), 0x112233);
+});

--- a/tests/migration/feString.spec.js
+++ b/tests/migration/feString.spec.js
@@ -1,0 +1,31 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const FEString = require('../../packages/core-js/src/feString');
+
+test('replace/unHTML/replaceBackSlashN behave as expected', () => {
+  assert.equal(FEString.replace('a-b-a', 'a', 'x'), 'x-b-x');
+  assert.equal(FEString.unHTML('<a&b>'), '&lt;a&amp;b&gt;');
+  assert.equal(FEString.replaceBackSlashN('line1\\nline2'), 'line1\nline2');
+});
+
+test('decode62 and repeat helpers', () => {
+  assert.equal(FEString.decode62('a'), 10);
+  assert.equal(FEString.decode62('A'), 36);
+  assert.equal(FEString.repeat('ab', 3), 'ababab');
+});
+
+test('trim and character helpers', () => {
+  assert.equal(FEString.rmChr('a-b-c', '-'), 'abc');
+  assert.equal(FEString.ltrim('   hello'), 'hello');
+  assert.equal(FEString.rtrim('hello   '), 'hello');
+  assert.equal(FEString.trim('  hello  '), 'hello');
+});
+
+test('string predicates', () => {
+  assert.equal(FEString.countUpperCase('AbCDx'), 3);
+  assert.equal(FEString.startsWith('frutiparc', 'fru'), true);
+  assert.equal(FEString.endsWith('frutiparc', 'parc'), true);
+  assert.equal(FEString.checkRepeat('aaab', 2), true);
+  assert.equal(FEString.checkRepeat('abab', 2), false);
+});

--- a/tests/migration/fecmItem.spec.js
+++ b/tests/migration/fecmItem.spec.js
@@ -1,0 +1,38 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { FECMItem } = require('../../packages/core-js/src/fecmItem');
+
+test('FECMItem stores constructor data', () => {
+  const cb = { obj: {}, method: 'x', args: 42 };
+  const item = new FECMItem('Demo', cb, false, true, true);
+
+  assert.equal(item.caption, 'Demo');
+  assert.equal(item.callBack, cb);
+  assert.equal(item.flSeparatorBefore, false);
+  assert.equal(item.flEnabled, true);
+  assert.equal(item.flVisible, true);
+});
+
+test('FECMItem.onSelect invokes callback method with args', () => {
+  const calls = [];
+  const target = {
+    open(value) {
+      calls.push(value);
+      return `ok:${value}`;
+    },
+  };
+
+  const item = new FECMItem(
+    'Open',
+    { obj: target, method: 'open', args: 'profile' },
+    false,
+    true,
+    true
+  );
+
+  const result = FECMItem.onSelect(null, item);
+
+  assert.deepEqual(calls, ['profile']);
+  assert.equal(result, 'ok:profile');
+});

--- a/tests/migration/femc.spec.js
+++ b/tests/migration/femc.spec.js
@@ -1,0 +1,63 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { FEMC } = require('../../packages/core-js/src/femc');
+
+test('FEMC setColor/killColor transforms', () => {
+  const mc = {};
+
+  const tr = FEMC.setColor(mc, 0x336699, false);
+  assert.deepEqual(tr, {
+    rb: 51 - 255,
+    gb: 102 - 255,
+    bb: 153 - 255,
+    ra: 100,
+    ga: 100,
+    ba: 100,
+  });
+
+  const trNeg = FEMC.setColor(mc, { r: 10, g: 20, b: 30 }, true);
+  assert.equal(trNeg.ra, -100);
+  assert.equal(trNeg.rb, 10);
+
+  const reset = FEMC.killColor(mc);
+  assert.deepEqual(reset, {
+    ra: 100, ga: 100, ba: 100, aa: 100, rb: 0, gb: 0, bb: 0, ab: 0,
+  });
+});
+
+test('FEMC setPColor and morphToButton hooks', () => {
+  const mc = {};
+  const tr = FEMC.setPColor(mc, 0x112233, 80);
+  assert.equal(tr.ra, 80);
+  assert.equal(tr.rb, 17 * 0.2);
+
+  const events = [];
+  const button = {
+    frames: [],
+    gotoAndStop(f) { this.frames.push(f); },
+    stop() { this.stopped = true; },
+    onFrutiRollOver() { events.push('over'); },
+    onFrutiRollOut() { events.push('out'); },
+    onFrutiPress() { events.push('press'); },
+    onFrutiRelease() { events.push('release'); },
+  };
+
+  FEMC.morphToButton(button);
+  button.onRollOver();
+  button.onRollOut();
+  button.onPress();
+  button.onRelease();
+
+  assert.deepEqual(button.frames, [2, 1, 3, 2]);
+  assert.deepEqual(events, ['over', 'out', 'press', 'release']);
+  assert.equal(button.stopped, true);
+});
+
+test('FEMC toString builds clip path', () => {
+  const root = { isRoot: true };
+  const p1 = { _name: 'a', _parent: root };
+  const p2 = { _name: 'b', _parent: p1 };
+
+  assert.equal(FEMC.toString(p2), '[MovieClip: _root.a.b]');
+});

--- a/tests/migration/femcLoader.spec.js
+++ b/tests/migration/femcLoader.spec.js
@@ -1,0 +1,38 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { FEMCLoader } = require('../../packages/core-js/src/femcLoader');
+
+test('FEMCLoader deduplicates in-flight loads per URL', () => {
+  FEMCLoader.urlList = {};
+  const calls = [];
+
+  const l1 = new FEMCLoader((url, target) => calls.push(['load', 'l1', url, target.id]));
+  const l2 = new FEMCLoader((url, target) => calls.push(['load', 'l2', url, target.id]));
+
+  l1.loadClip('/a.swf', { id: 'mc1' });
+  l2.loadClip('/a.swf', { id: 'mc2' });
+
+  assert.deepEqual(calls, [['load', 'l1', '/a.swf', 'mc1']]);
+
+  l1.onLoadComplete({ id: 'mc1' });
+
+  assert.deepEqual(calls, [
+    ['load', 'l1', '/a.swf', 'mc1'],
+    ['load', 'l2', '/a.swf', 'mc2'],
+  ]);
+  assert.equal(FEMCLoader.urlList['/a.swf'].loaded, true);
+});
+
+test('FEMCLoader loads immediately when URL already loaded', () => {
+  FEMCLoader.urlList = {
+    '/done.swf': { loaded: true, objList: [] },
+  };
+
+  const calls = [];
+  const loader = new FEMCLoader((url, target) => calls.push([url, target.id]));
+
+  loader.loadClip('/done.swf', { id: 'mcX' });
+
+  assert.deepEqual(calls, [['/done.swf', 'mcX']]);
+});

--- a/tests/migration/fileLoader.spec.js
+++ b/tests/migration/fileLoader.spec.js
@@ -1,0 +1,55 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { FileLoader } = require('../../packages/core-js/src/fileLoader');
+
+test('FileLoader tracks progress and emits events', () => {
+  const events = [];
+  const listener = {
+    onLoadStart() { events.push('start'); },
+    onLoadProgress(_mc, loaded, total) { events.push(`progress:${loaded}/${total}`); },
+    onLoadComplete() { events.push('complete'); },
+  };
+
+  const loader = new FileLoader('/asset.swf', 1000);
+  loader.addListener(listener);
+
+  loader.loadClip({ id: 'mc1' }, 1000);
+  loader.onLoadStart();
+  loader.onLoadProgress({ id: 'mc1' }, 250, 1000, 1500);
+  loader.onLoadComplete({ bytesLoaded: 1000, bytesTotal: 1000 });
+
+  assert.equal(loader.loaded, true);
+  assert.equal(loader.percent, 25);
+  assert.equal(loader.bytesToLoad, 750);
+  assert.deepEqual(events, ['start', 'progress:250/1000', 'complete']);
+});
+
+test('FileLoader emits false-size error when loaded size differs', () => {
+  let falseSize = 0;
+  const listener = {
+    onFalseSizeError() { falseSize += 1; },
+  };
+
+  const loader = new FileLoader('/asset.swf', 500);
+  loader.addListener(listener);
+  loader.onLoadComplete({ bytesLoaded: 400, bytesTotal: 400 });
+  loader.onLoadInit();
+
+  assert.equal(falseSize, 2);
+  assert.equal(loader.loaded, false);
+});
+
+test('FileLoader not-found path emits expected event', () => {
+  let notFound = 0;
+  const listener = {
+    onFileNotFoundError() { notFound += 1; },
+  };
+
+  const loader = new FileLoader('/missing.swf');
+  loader.addListener(listener);
+  loader.onLoadError('404', 'Not Found');
+
+  assert.equal(notFound, 1);
+  assert.equal(loader.loaded, false);
+});

--- a/tests/migration/http.spec.js
+++ b/tests/migration/http.spec.js
@@ -1,0 +1,52 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { HTTP } = require('../../packages/core-js/src/http');
+
+test('HTTP processes queue sequentially and merges default params', async () => {
+  HTTP.queue = [];
+  HTTP.flIdle = true;
+  HTTP.defaultParams = { token: 'abc' };
+
+  const events = [];
+  const callbackObj = {
+    onResult(success, data, extra) {
+      events.push(['callback', success, data.action, extra]);
+    },
+  };
+
+  const transport = (action, output, method, done) => {
+    events.push(['submit', action, method, output.token, output.local]);
+    setTimeout(() => done(true, { action }), 5);
+  };
+
+  new HTTP('do/one', { local: 'x' }, { obj: callbackObj, method: 'onResult' }, 'GET', 'e1', transport);
+  new HTTP('do/two', { local: 'y' }, { obj: callbackObj, method: 'onResult' }, 'POST', 'e2', transport);
+
+  await new Promise((resolve) => setTimeout(resolve, 40));
+
+  assert.deepEqual(events, [
+    ['submit', 'do/one', 'GET', 'abc', 'x'],
+    ['callback', true, 'do/one', 'e1'],
+    ['submit', 'do/two', 'POST', 'abc', 'y'],
+    ['callback', true, 'do/two', 'e2'],
+  ]);
+  assert.equal(HTTP.flIdle, true);
+});
+
+test('HTTP without transport fails gracefully', () => {
+  HTTP.queue = [];
+  HTTP.flIdle = true;
+
+  let called = null;
+  const callbackObj = {
+    onResult(success, data, extra) {
+      called = { success, data, extra };
+    },
+  };
+
+  new HTTP('do/none', {}, { obj: callbackObj, method: 'onResult' }, 'GET', 'extra', null);
+
+  assert.deepEqual(called, { success: false, data: null, extra: 'extra' });
+  assert.equal(HTTP.flIdle, true);
+});

--- a/tests/migration/lang.spec.js
+++ b/tests/migration/lang.spec.js
@@ -1,0 +1,59 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { Lang } = require('../../packages/core-js/src/lang');
+
+const langText = {
+  greet: 'Salut $n',
+  date: {
+    day_short: { 2: 'mar' },
+    day: { 2: 'mardi' },
+    month_short: { 1: 'janv' },
+    month: { 1: 'janvier' },
+    format_default: '$Y/$N/$D',
+  },
+  duration: {
+    format_default: {
+      h: '$h h',
+      i: '$i min',
+      s: '$s sec',
+      m: '$m ms',
+    },
+  },
+  ordinal: { first: 'er', second: 'e', third: 'e', fourth: 'e', fifth: 'e', def: 'e' },
+  countries: {
+    FR: { name: 'France', region: { IDF: 'Île-de-France' } },
+  },
+  sign: { 1: 'Bélier' },
+  disc_to_game: { miniboom: 'Mini Boom' },
+  tip_doc: { t1: 'Astuce 1' },
+};
+
+test('fv formats language string variables', () => {
+  assert.equal(Lang.fv('greet', { n: 'Bob' }, langText), 'Salut Bob');
+  assert.equal(Lang.fv('unknown.path', { n: 'Bob' }, langText), '[ERR] unknown.path');
+});
+
+test('date formatting helpers', () => {
+  const date = new Date(2024, 0, 2, 3, 4, 5);
+  assert.equal(Lang.formatDate(date, 'default', langText), '2024/01/02');
+  assert.equal(Lang.formatDateString('2024-01-02 03:04:05', 'default', langText), '2024/01/02');
+  assert.equal(Lang.formatDateTime(date.getTime(), 'default', langText), '2024/01/02');
+});
+
+test('duration and ordinal helpers', () => {
+  assert.equal(Lang.formatDuration(3000, 'default', langText), '3 sec');
+  assert.equal(Lang.card2ord(1, langText), '1er');
+  assert.equal(Lang.card2ord(8, langText), '8e');
+});
+
+test('country/region/sign/game/tip helpers', () => {
+  assert.equal(Lang.country('FR', langText), 'France');
+  assert.equal(Lang.country('XX', langText), 'Inconnu');
+  assert.equal(Lang.region('FR', 'IDF', langText), 'Île-de-France');
+  assert.equal(Lang.region('FR', '??', langText), 'Inconnu');
+  assert.equal(Lang.sign(1, langText), 'Bélier');
+  assert.equal(Lang.gameName('miniboom', langText), 'Mini Boom');
+  assert.equal(Lang.gameName('unknown', langText), 'unknown');
+  assert.equal(Lang.getTipDoc('t1', langText), 'Astuce 1');
+});

--- a/tests/migration/md5.spec.js
+++ b/tests/migration/md5.spec.js
@@ -1,0 +1,11 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const MD5 = require('../../packages/core-js/src/md5');
+
+test('MD5 encode matches standard test vectors', () => {
+  assert.equal(MD5.encode(''), 'd41d8cd98f00b204e9800998ecf8427e');
+  assert.equal(MD5.encode('a'), '0cc175b9c0f1b6a831c399e269772661');
+  assert.equal(MD5.encode('abc'), '900150983cd24fb0d6963f7d28e17f72');
+  assert.equal(MD5.encode('message digest'), 'f96b697d7cb7938d525a2f31aaf161d0');
+});

--- a/tests/migration/mvpShowcase.spec.js
+++ b/tests/migration/mvpShowcase.spec.js
@@ -1,0 +1,18 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { buildMvpShowcase } = require('../../packages/core-js/src/mvpShowcase');
+
+test('MVP showcase returns stable structure from migrated modules', () => {
+  const payload = buildMvpShowcase();
+
+  assert.equal(payload.version, 'mvp-haxe-node');
+  assert.equal(typeof payload.generatedAt, 'string');
+
+  assert.equal(payload.modules.feString, 'Salut Frutiparc, build Haxe/Node');
+  assert.deepEqual(payload.modules.feColor, { r: 255, g: 136, b: 0 });
+
+  assert.equal(typeof payload.modules.statusMng.external, 'string');
+  assert.equal(typeof payload.modules.classLoader.firstUrl, 'string');
+  assert.equal(payload.modules.classLoader.nextLibLoaded, 1);
+});

--- a/tests/migration/pref.spec.js
+++ b/tests/migration/pref.spec.js
@@ -1,0 +1,78 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { Pref } = require('../../packages/core-js/src/pref');
+const FENumber = require('../../packages/core-js/src/feNumber');
+
+function prefDefChunk(id, typeCode, name, defaultValue) {
+  return (
+    FENumber.encode62(id, 2) +
+    typeCode +
+    FENumber.encode62(name.length, 2) +
+    name +
+    FENumber.encode62(defaultValue.length, 2) +
+    defaultValue
+  );
+}
+
+test('onLoadPrefDef parses pref definitions', () => {
+  const pref = new Pref();
+  const data = {
+    PrefDef:
+      prefDefChunk(1, 'b', 'music', 'Y') +
+      prefDefChunk(2, 'i', 'volume', '0a') +
+      prefDefChunk(3, 's', 'theme', 'classic'),
+  };
+
+  pref.onLoadPrefDef(true, data);
+
+  assert.equal(pref.prefs.music.type, 'bool');
+  assert.equal(pref.prefs.music.default_value, true);
+  assert.equal(pref.prefs.volume.default_value, 10);
+  assert.equal(pref.prefs.theme.default_value, 'classic');
+});
+
+test('useMyPref applies packed user preferences', () => {
+  const pref = new Pref();
+  pref.onLoadPrefDef(true, {
+    PrefDef:
+      prefDefChunk(1, 'b', 'music', 'Y') +
+      prefDefChunk(2, 'i', 'volume', '0a') +
+      prefDefChunk(3, 's', 'theme', 'classic'),
+  });
+
+  const packed =
+    FENumber.encode62(1, 2) + FENumber.encode62(1, 2) + 'N' +
+    FENumber.encode62(2, 2) + FENumber.encode62(2, 2) + '1Z' +
+    FENumber.encode62(3, 2) + FENumber.encode62(4, 2) + 'dark';
+
+  pref.useMyPref(packed);
+
+  assert.equal(pref.getPref('music'), false);
+  assert.equal(pref.getPref('volume'), 123);
+  assert.equal(pref.getPref('theme'), 'dark');
+});
+
+test('getFormatedPref serializes only non-default values', () => {
+  const pref = new Pref();
+  pref.onLoadPrefDef(true, {
+    PrefDef: prefDefChunk(1, 'b', 'music', 'Y') + prefDefChunk(2, 'i', 'volume', '0a'),
+  });
+
+  pref.setPref('music', false);
+  pref.setPref('volume', 10); // default, should not be serialized
+
+  const out = pref.getFormatedPref();
+  const expected = FENumber.encode62(1, 2) + FENumber.encode62(1, 2) + 'N';
+  assert.equal(out, expected);
+});
+
+test('getACopy returns deep copy of prefs', () => {
+  const pref = new Pref();
+  pref.onLoadPrefDef(true, { PrefDef: prefDefChunk(1, 's', 'theme', 'classic') });
+
+  const copy = pref.getACopy();
+  copy.theme.value = 'hacked';
+
+  assert.equal(pref.getPref('theme'), 'classic');
+});

--- a/tests/migration/runDate.spec.js
+++ b/tests/migration/runDate.spec.js
@@ -1,0 +1,43 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { RunDate } = require('../../packages/core-js/src/runDate');
+
+test('RunDate returns near-now time before reference is set', () => {
+  const rd = new RunDate();
+  const now = Date.now();
+  const t = rd.getTime();
+  assert.ok(Math.abs(t - now) < 1000);
+});
+
+test('setFromString updates diff and aligned object helpers', () => {
+  const rd = new RunDate();
+  rd.setFromString('2024-03-05 06:07:08');
+
+  const obj = rd.getObject();
+  assert.equal(obj.y, '2024');
+  assert.equal(obj.m, '03');
+  assert.equal(obj.d, '05');
+
+  const complete = rd.getCompleteObject();
+  assert.equal(complete.Y, '2024');
+  assert.equal(complete.N, '03');
+});
+
+test('toFormat delegates to formatter callback', () => {
+  const rd = new RunDate();
+  rd.setFromString('2024-03-05 06:07:08');
+
+  const out = rd.toFormat('Y-N-D', (o, fmt) => `${fmt}:${o.Y}-${o.N}-${o.D}`);
+  assert.equal(out, 'Y-N-D:2024-03-05');
+});
+
+test('getCurrentFSign returns expected shape', () => {
+  const rd = new RunDate();
+  const sign = rd.getCurrentFSign();
+
+  assert.equal(typeof sign.sign, 'number');
+  assert.equal(typeof sign.signb, 'number');
+  assert.equal(typeof sign.signCompletion, 'number');
+  assert.equal(typeof sign.signbCompletion, 'number');
+});

--- a/tests/migration/slot.spec.js
+++ b/tests/migration/slot.spec.js
@@ -1,0 +1,103 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { Slot } = require('../../packages/core-js/src/slot');
+
+function makeBox(name) {
+  return {
+    name,
+    initCalls: [],
+    depthCalls: [],
+    active: 0,
+    deactive: 0,
+    slotActive: 0,
+    slotDeactive: 0,
+    closeCalls: 0,
+    init(...args) { this.initCalls.push(args); },
+    setDepth(depth) { this.depthCalls.push(depth); },
+    onActivate() { this.active += 1; },
+    onDeactivate() { this.deactive += 1; },
+    onSlotActivate() { this.slotActive += 1; },
+    onSlotDeactivate() { this.slotDeactive += 1; },
+    tryToClose() { this.closeCalls += 1; },
+  };
+}
+
+test('Slot addBox/activate/rmBox lifecycle', () => {
+  Slot.depths = { boxList: { start: 10, dst: 2, max: 20 } };
+
+  const slot = new Slot();
+  const listCalls = [];
+  slot.init({ activate(s) { listCalls.push(s); }, rmSlot() {} }, 100, true);
+  assert.equal(listCalls.length, 1);
+
+  const a = makeBox('a');
+  const b = makeBox('b');
+
+  slot.addBox(a);
+  slot.addBox(b);
+
+  assert.deepEqual(a.initCalls[0], [slot, 110]);
+  assert.deepEqual(b.initCalls[0], [slot, 114]);
+  assert.equal(slot.nbBox, 2);
+  assert.equal(a.deactive, 1);
+  assert.equal(b.active, 1);
+
+  slot.rmBox(a);
+  assert.equal(slot.nbBox, 1);
+});
+
+test('Slot cleanDepths/putOnTop/move/update title', () => {
+  Slot.depths = { boxList: { start: 0, dst: 5, max: 1 } };
+
+  const slotA = new Slot();
+  slotA.init({ activate() {}, rmSlot() {} }, 50, false);
+  const slotB = new Slot();
+  slotB.init({ activate() {}, rmSlot() {} }, 200, false);
+
+  const a = makeBox('a');
+  const b = makeBox('b');
+
+  slotA.addBox(a);
+  slotA.addBox(b); // triggers cleanDepths path due to max
+  slotA.rmBox(a);
+  slotA.cleanDepths();
+  assert.equal(b.depthCalls.at(-1), 50);
+
+  slotA.putOnTop(b);
+  assert.equal(b.depthCalls.at(-1), 70);
+
+  slotA.move(b, slotB);
+  assert.equal(slotA.nbBox, 0);
+  assert.equal(slotB.nbBox, 1);
+
+  slotB.setTitle('Chat');
+  assert.equal(slotB.title, 'Chat');
+});
+
+test('Slot warning/activate/deactivate/close flow', () => {
+  const removed = [];
+  const slot = new Slot();
+  slot.init({ activate() {}, rmSlot(s) { removed.push(s); } }, 0, false);
+
+  const box = makeBox('box');
+  slot.addBox(box);
+
+  assert.equal(slot.warning(), true);
+  assert.equal(slot.warning(), false);
+
+  slot.onActivate();
+  assert.equal(slot.flWarning, false);
+  assert.equal(box.slotActive, 1);
+
+  slot.onDeactivate();
+  assert.equal(box.slotDeactive, 1);
+
+  slot.tryToClose();
+  assert.equal(box.closeCalls, 1);
+
+  slot.arr = [];
+  slot.tryToClose();
+  assert.equal(slot.flClose, true);
+  assert.equal(removed.length, 1);
+});

--- a/tests/migration/slotList.spec.js
+++ b/tests/migration/slotList.spec.js
@@ -1,0 +1,77 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { SlotList } = require('../../packages/core-js/src/slotList');
+
+function makeSlot(name) {
+  return {
+    name,
+    flClose: false,
+    initCalls: [],
+    depthCalls: [],
+    activated: 0,
+    deactivated: 0,
+    init(...args) { this.initCalls.push(args); },
+    setDepth(depth) { this.depthCalls.push(depth); },
+    onActivate() { this.activated += 1; },
+    onDeactivate() { this.deactivated += 1; },
+  };
+}
+
+test('SlotList add/rm/init depth flow', () => {
+  SlotList.depths = { slotList: { start: 100, dst: 10, max: 105 } };
+
+  const list = new SlotList();
+  list.init();
+
+  const a = makeSlot('a');
+  const b = makeSlot('b');
+
+  list.addSlot(a, true);
+  list.addSlot(b, false);
+
+  assert.deepEqual(a.initCalls[0], [list, 100, true]);
+  assert.deepEqual(b.initCalls[0], [list, 110, false]);
+  assert.equal(list.rmSlot(a), true);
+  assert.equal(list.rmSlot(a), false);
+});
+
+test('SlotList cleanDepths and putOnTop reorder depths', () => {
+  SlotList.depths = { slotList: { start: 10, dst: 2, max: 11 } };
+
+  const list = new SlotList();
+  const a = makeSlot('a');
+  const b = makeSlot('b');
+  const c = makeSlot('c');
+
+  list.addSlot(a, false);
+  list.addSlot(b, false);
+  list.addSlot(c, false); // triggers cleanDepths due to max
+
+  list.rmSlot(b);
+  list.cleanDepths();
+
+  assert.equal(a.depthCalls.at(-1), 10);
+  assert.equal(c.depthCalls.at(-1), 12);
+
+  list.putOnTop(a);
+  assert.equal(a.depthCalls.at(-1), 16);
+});
+
+test('SlotList activate switches active slot', () => {
+  const list = new SlotList();
+  const a = makeSlot('a');
+  const b = makeSlot('b');
+
+  assert.equal(list.activate(undefined), false);
+  assert.equal(list.activate(a), true);
+  assert.equal(list.activate(a), false);
+
+  b.flClose = true;
+  assert.equal(list.activate(b), false);
+  b.flClose = false;
+
+  assert.equal(list.activate(b), true);
+  assert.equal(a.deactivated, 1);
+  assert.equal(b.activated, 1);
+});

--- a/tests/migration/statusMng.spec.js
+++ b/tests/migration/statusMng.spec.js
@@ -1,0 +1,57 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { StatusMng } = require('../../packages/core-js/src/statusMng');
+
+test('StatusMng.analyseStr decodes external/internal/emote', () => {
+  const decoded = StatusMng.analyseStr('102A');
+  assert.deepEqual(decoded, {
+    external: 'eat',
+    internal: 'bkiwi',
+    emote: 36,
+  });
+});
+
+test('StatusMng send deduplicates payloads and pushes via cnx.cmd', () => {
+  const status = new StatusMng();
+  const calls = [];
+
+  status.setCnx({
+    cmd(name, payload) {
+      calls.push([name, payload]);
+    },
+  });
+
+  status.setExternal('work');
+  status.setInternal('mb2');
+  status.setEmote(5);
+
+  const before = calls.length;
+  status.send();
+  assert.equal(calls.length, before);
+
+  assert.deepEqual(calls, [
+    ['status', { s: '200' }],
+    ['status', { s: '203' }],
+    ['status', { s: '2035' }],
+  ]);
+});
+
+test('StatusMng unsetInternal only sends when current internal matches', () => {
+  const status = new StatusMng();
+  const calls = [];
+
+  status.setCnx({
+    cmd(name, payload) {
+      calls.push([name, payload]);
+    },
+  });
+
+  status.setInternal('snake3');
+  status.unsetInternal('forum');
+  assert.equal(calls.length, 1);
+
+  status.unsetInternal('snake3');
+  assert.equal(calls.length, 2);
+  assert.deepEqual(calls.at(-1), ['status', { s: '000' }]);
+});

--- a/tests/migration/tab.spec.js
+++ b/tests/migration/tab.spec.js
@@ -1,0 +1,47 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { Tab } = require('../../packages/core-js/src/tab');
+
+function makeBox(name) {
+  return {
+    name,
+    initCalls: [],
+    setDepthCalls: [],
+    init(...args) { this.initCalls.push(args); },
+    setDepth(depth) { this.setDepthCalls.push(depth); },
+    onActivate() {},
+    onDeactivate() {},
+    onSlotActivate() {},
+    onSlotDeactivate() {},
+    tryToClose() {},
+  };
+}
+
+test('Tab accepts only one box', () => {
+  const removed = [];
+  const tab = new Tab();
+  tab.init({ activate() {}, rmSlot(slot) { removed.push(slot); } }, 50, false);
+
+  const box1 = makeBox('b1');
+  const box2 = makeBox('b2');
+
+  assert.equal(tab.addBox(box1), true);
+  assert.equal(tab.nbBox, 1);
+  assert.equal(tab.addBox(box2), false);
+  assert.equal(tab.nbBox, 1);
+});
+
+test('Tab rmBox compacts depth and closes when empty', () => {
+  const removed = [];
+  const tab = new Tab();
+  tab.init({ activate() {}, rmSlot(slot) { removed.push(slot); } }, 10, false);
+
+  const box = makeBox('b1');
+  tab.addBox(box);
+
+  tab.rmBox(box);
+  assert.equal(tab.nbBox, 0);
+  assert.equal(tab.flClose, true);
+  assert.equal(removed.length, 1);
+});

--- a/tests/migration/userListMng.spec.js
+++ b/tests/migration/userListMng.spec.js
@@ -1,0 +1,79 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { UserListMng } = require('../../packages/core-js/src/userListMng');
+
+test('UserListMng add/remove and sorted projection', () => {
+  const list = new UserListMng();
+
+  list.addUser('zoe', {}, false, false);
+  list.addUser('alice', {}, true, false);
+  list.addUser('bob', {}, false, false);
+
+  assert.equal(list.length, 3);
+
+  list.onChange();
+  assert.deepEqual(list.getUserArray(), ['alice', 'bob', 'zoe']);
+  assert.equal(list.modePresent(), true);
+  assert.equal(list.isMode('alice'), true);
+
+  assert.equal(list.getRealUserName('ALICE'), 'alice');
+  assert.equal(list.isInList('zoe'), true);
+
+  assert.equal(list.rmUser('bob', false), true);
+  assert.equal(list.length, 2);
+  assert.deepEqual(list.getUserArray(), ['alice', 'zoe']);
+});
+
+test('UserListMng listeners receive paged updates', () => {
+  const list = new UserListMng();
+  list.addUser('charlie', {}, false, false);
+  list.addUser('alice', {}, false, false);
+  list.addUser('bob', {}, false, false);
+  list.onChange();
+
+  const events = [];
+  const listener = {
+    onList(users, total) {
+      events.push({ users, total });
+    },
+  };
+
+  list.wantList(listener, 'onList', 1, 2);
+  assert.deepEqual(events.at(-1), { users: ['bob', 'charlie'], total: 3 });
+
+  list.rmUser('bob');
+  assert.deepEqual(events.at(-1), { users: ['charlie'], total: 2 });
+
+  assert.equal(list.noMoreList(listener), true);
+  list.addUser('david');
+  assert.equal(events.length, 2);
+});
+
+test('UserListMng routes mc and action calls to users', () => {
+  const list = new UserListMng();
+  list.addUser('alice', {}, false, false);
+
+  const events = [];
+  const mc = {
+    onInfoBasic(obj) {
+      events.push(['info', obj.nickname]);
+    },
+    onAction(act) {
+      events.push(['action', act]);
+    },
+  };
+
+  list.defineMc('alice', mc);
+  list.onUserAction('alice', 'wave');
+  list.undefineMc('alice', mc);
+
+  assert.deepEqual(events, [
+    ['info', 'alice'],
+    ['action', 'wave'],
+  ]);
+
+  list.rmAll();
+  assert.equal(list.length, 0);
+  assert.deepEqual(list.getUserArray(), []);
+});

--- a/tests/migration/userMng.spec.js
+++ b/tests/migration/userMng.spec.js
@@ -1,0 +1,60 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { UserMng } = require('../../packages/core-js/src/userMng');
+
+const langText = {
+  countries: { FR: { name: 'France', region: { IDF: 'Île-de-France' } } },
+};
+
+test('UserMng XP helpers', () => {
+  assert.equal(UserMng.xpToLevel(0), 1);
+  assert.equal(UserMng.levelToXp(1), 0);
+  assert.equal(UserMng.levelToXp(3), 40000);
+  assert.equal(UserMng.xpToLevel(40000), 3);
+  assert.equal(UserMng.xpLevelCompletionRate(45000), 0.1);
+});
+
+test('UserMng birthday helpers', () => {
+  const now = new Date(2024, 5, 15);
+  assert.equal(UserMng.birthdayToAge('2000-06-10', now), 24);
+  assert.equal(UserMng.birthdayToAge('2000-06-20', now), 23);
+  assert.equal(UserMng.birthdayToMonthAge('2024-04-20 00:00:00', now), 1);
+});
+
+test('formatInfoBasic maps profile fields', () => {
+  const now = new Date(2024, 5, 15);
+  const node = {
+    attributes: { x: '45000', u: 'Bob', sx: 'M', bd: '2000-06-10', co: 'FR', rg: 'IDF' },
+  };
+
+  const info = UserMng.formatInfoBasic(node, now, langText);
+  assert.equal(info.nickname, 'Bob');
+  assert.equal(info.country, 'France');
+  assert.equal(info.region, 'Île-de-France');
+  assert.equal(info.xpLevel, 3);
+});
+
+test('instance methods manage listeners and info updates', () => {
+  const user = new UserMng('Alice', { gender: 'F' }, true);
+
+  const events = [];
+  const mc = {
+    onInfoBasic(obj) { events.push(['info', obj.nickname || obj.gender]); },
+    onAction(act) { events.push(['action', act]); },
+  };
+
+  user.setMc(mc);
+  user.onAction('wave');
+  user.onStatusObj({ nickname: 'Alice2', flMute: true });
+  user.unsetMc(mc);
+
+  assert.equal(user.sortString, '0alice');
+  assert.equal(user.getInfoBasic().nickname, 'Alice2');
+  assert.equal(user.getInfoBasic().flMute, true);
+  assert.deepEqual(events, [
+    ['info', 'Alice'],
+    ['action', 'wave'],
+    ['info', 'Alice2'],
+  ]);
+});

--- a/tests/migration/winBox.spec.js
+++ b/tests/migration/winBox.spec.js
@@ -1,0 +1,71 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { WinBox } = require('../../packages/core-js/src/winBox');
+
+test('WinBox init/preInit and visibility toggles', () => {
+  const box = new WinBox();
+  const slot = { rmBox() {}, activate() {}, move() {} };
+
+  assert.equal(box.init(slot, 42), true);
+  assert.equal(box.title, '');
+  assert.equal(box.flShow, true);
+
+  box.title = 'Persisted';
+  assert.equal(box.init(slot, 50), false);
+  assert.equal(box.title, 'Persisted');
+
+  box.hide();
+  assert.equal(box.flShow, false);
+  box.show();
+  assert.equal(box.flShow, true);
+});
+
+test('WinBox activate/deactivate and slot activation hooks', () => {
+  const box = new WinBox();
+  box.init({ rmBox() {}, activate() {}, move() {} }, 1);
+
+  box.onActivate();
+  assert.equal(box.flActive, true);
+  box.onDeactivate();
+  assert.equal(box.flActive, false);
+
+  box.flShow = true;
+  box.onSlotDeactivate();
+  assert.equal(box.wasShow, true);
+  assert.equal(box.flShow, false);
+
+  box.onSlotActivate();
+  assert.equal(box.wasShow, false);
+  assert.equal(box.flShow, true);
+});
+
+test('WinBox delegates close/activate/move to slot', () => {
+  const calls = [];
+  const slotA = {
+    rmBox(box) { calls.push(['rmBox', box]); },
+    activate(box) { calls.push(['activate', box]); },
+    move(box, newSlot) { calls.push(['move', box, newSlot]); },
+  };
+  const slotB = {};
+
+  const box = new WinBox();
+  box.init(slotA, 5);
+
+  box.setDepth(8);
+  assert.equal(box.depth, 8);
+
+  box.activate();
+  assert.equal(calls[0][0], 'activate');
+
+  assert.equal(box.move(slotA), false);
+  assert.equal(box.move(slotB), true);
+  assert.equal(calls[1][0], 'move');
+
+  box.tryToClose();
+  assert.equal(box.flClosed, true);
+  assert.equal(calls[2][0], 'rmBox');
+
+  box.setTitle('My title');
+  assert.equal(box.title, 'My title');
+});

--- a/tests/migration/winStandard.spec.js
+++ b/tests/migration/winStandard.spec.js
@@ -1,0 +1,58 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { WinStandard } = require('../../packages/core-js/src/winStandard');
+
+test('WinStandard init defaults and desktop recal/resize', () => {
+  WinStandard.env = { frameMode: false, mcw: 300, mch: 200, cornerX: 10, cornerY: 20, tmod: 1 };
+
+  const win = new WinStandard();
+  win.init();
+
+  assert.equal(win.flInterface, true);
+  assert.equal(win.flResizable, true);
+  assert.equal(win.flMoveAnim, true);
+
+  win.minimum = { w: 80, h: 70 };
+  win.pos = { x: -5, y: -8, w: 500, h: 500 };
+
+  assert.equal(win.recal(), true);
+  assert.deepEqual(win.pos, { x: 10, y: 20, w: 290, h: 180 });
+
+  win.resize(100, 90);
+  assert.deepEqual(win.pos, { x: 10, y: 20, w: 100, h: 90 });
+  assert.equal(win.xPos, 10);
+  assert.equal(win.yPos, 20);
+});
+
+test('WinStandard tab mode updates position and size', () => {
+  WinStandard.env = { frameMode: false, mcw: 640, mch: 480, cornerX: 30, cornerY: 40, tmod: 1 };
+
+  const win = new WinStandard();
+  win.init();
+  win.box.mode = 'tab';
+
+  win.onChangeMode();
+  assert.equal(win.xPos, 30);
+  assert.equal(win.yPos, 40);
+  assert.deepEqual(win.tab, { w: 610, h: 440 });
+});
+
+test('WinStandard helpers: frameMode, title, gelatine', () => {
+  WinStandard.env = { frameMode: true, mcw: 200, mch: 100, cornerX: 0, cornerY: 0, tmod: 2 };
+
+  const win = new WinStandard();
+  win.pos = { x: -20, y: -20, w: 300, h: 200 };
+  win.minimum = { w: 50, h: 50 };
+
+  assert.equal(win.recal(), false); // disabled by frameMode
+
+  win.setTitle('Main chat');
+  assert.equal(win.title, 'Main chat');
+
+  const x0 = win.xScale;
+  const y0 = win.yScale;
+  win.gelatine();
+  assert.notEqual(win.xScale, x0);
+  assert.notEqual(win.yScale, y0);
+});

--- a/tests/migration/window.spec.js
+++ b/tests/migration/window.spec.js
@@ -1,0 +1,15 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { Window } = require('../../packages/core-js/src/window');
+
+test('Window can be instantiated', () => {
+  const instance = new Window();
+  assert.ok(instance instanceof Window);
+});
+
+test('Window init exists and returns undefined (void semantics)', () => {
+  const instance = new Window();
+  assert.equal(typeof instance.init, 'function');
+  assert.equal(instance.init(), undefined);
+});

--- a/tools/migration/inventory_as2.js
+++ b/tools/migration/inventory_as2.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = process.cwd();
+const TARGET_DIRS = ['frutiengine', 'frutiparc'];
+const OUTPUT_FILE = path.join(ROOT, 'migration', 'inventory', 'as2-inventory.json');
+
+function walk(dir, collector) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(fullPath, collector);
+      continue;
+    }
+    if (entry.isFile() && fullPath.endsWith('.as')) {
+      collector.push(fullPath);
+    }
+  }
+}
+
+function parseFile(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const lines = content.split(/\r?\n/);
+
+  const classes = [...content.matchAll(/\bclass\s+([A-Za-z_][A-Za-z0-9_]*)/g)].map((m) => m[1]);
+  const extendsMatch = [...content.matchAll(/\bclass\s+[A-Za-z_][A-Za-z0-9_]*\s+extends\s+([A-Za-z_][A-Za-z0-9_.]*)/g)].map((m) => m[1]);
+  const imports = [...content.matchAll(/\bimport\s+([A-Za-z_][A-Za-z0-9_.]*)\s*;/g)].map((m) => m[1]);
+
+  return {
+    file: path.relative(ROOT, filePath),
+    lines: lines.length,
+    classes,
+    extends: extendsMatch,
+    imports,
+    hasOnClipEvent: /\bonClipEvent\b/.test(content),
+    hasAttachMovie: /\battachMovie\b/.test(content),
+    hasLoadMovie: /\bloadMovie\b/.test(content),
+    hasXml: /\bXML\b/.test(content),
+  };
+}
+
+function main() {
+  const files = [];
+  for (const dir of TARGET_DIRS) {
+    const full = path.join(ROOT, dir);
+    if (fs.existsSync(full)) {
+      walk(full, files);
+    }
+  }
+
+  const parsed = files
+    .map(parseFile)
+    .sort((a, b) => a.file.localeCompare(b.file, 'en'));
+
+  const summary = {
+    generatedAt: new Date().toISOString(),
+    fileCount: parsed.length,
+    totalLines: parsed.reduce((sum, f) => sum + f.lines, 0),
+    filesWithOnClipEvent: parsed.filter((f) => f.hasOnClipEvent).length,
+    filesWithAttachMovie: parsed.filter((f) => f.hasAttachMovie).length,
+    filesWithLoadMovie: parsed.filter((f) => f.hasLoadMovie).length,
+    filesWithXml: parsed.filter((f) => f.hasXml).length,
+  };
+
+  fs.mkdirSync(path.dirname(OUTPUT_FILE), { recursive: true });
+  fs.writeFileSync(
+    OUTPUT_FILE,
+    JSON.stringify({ summary, files: parsed }, null, 2) + '\n',
+    'utf8'
+  );
+
+  console.log(`AS2 inventory written to ${path.relative(ROOT, OUTPUT_FILE)}`);
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+main();

--- a/tools/migration/run_mvp.sh
+++ b/tools/migration/run_mvp.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "[1/2] Génération inventaire AS2..."
+node tools/migration/inventory_as2.js
+
+echo "[2/2] Sélection automatique du Lot A..."
+node tools/migration/select_lot_a.js
+
+echo ""
+echo "✅ MVP prêt à vérifier."
+echo "- Rapport lisible: docs/MVP_LOT_A.md"
+echo "- Données JSON : migration/inventory/lot-a-candidates.json"

--- a/tools/migration/select_lot_a.js
+++ b/tools/migration/select_lot_a.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = process.cwd();
+const INVENTORY_PATH = path.join(ROOT, 'migration', 'inventory', 'as2-inventory.json');
+const OUTPUT_JSON = path.join(ROOT, 'migration', 'inventory', 'lot-a-candidates.json');
+const OUTPUT_MD = path.join(ROOT, 'docs', 'MVP_LOT_A.md');
+
+function scoreFile(file) {
+  const penalty =
+    (file.hasAttachMovie ? 6 : 0) +
+    (file.hasLoadMovie ? 6 : 0) +
+    (file.hasOnClipEvent ? 6 : 0) +
+    (file.hasXml ? 2 : 0);
+
+  const classBonus = file.classes.length > 0 ? 2 : -2;
+  const sizePenalty = file.lines > 500 ? 4 : file.lines > 250 ? 2 : 0;
+  const engineBonus = file.file.startsWith('frutiengine/') ? 2 : 0;
+  const testPenalty = file.file.includes('test_game') ? 4 : 0;
+
+  const score = 10 + classBonus + engineBonus - penalty - sizePenalty - testPenalty;
+
+  return {
+    ...file,
+    score,
+    reasons: [
+      file.hasAttachMovie ? 'uses attachMovie' : null,
+      file.hasLoadMovie ? 'uses loadMovie' : null,
+      file.hasOnClipEvent ? 'uses onClipEvent' : null,
+      file.hasXml ? 'uses XML APIs' : null,
+      file.lines > 500 ? 'large file (>500 lines)' : null,
+      file.file.includes('test_game') ? 'test_game scope' : null,
+      file.classes.length === 0 ? 'no class declaration' : 'has class declaration',
+    ].filter(Boolean),
+  };
+}
+
+function main() {
+  if (!fs.existsSync(INVENTORY_PATH)) {
+    throw new Error(`Missing inventory file: ${path.relative(ROOT, INVENTORY_PATH)}. Run inventory_as2.js first.`);
+  }
+
+  const inventory = JSON.parse(fs.readFileSync(INVENTORY_PATH, 'utf8'));
+  const scored = inventory.files.map(scoreFile);
+
+  const candidates = scored
+    .filter((f) => !f.hasAttachMovie && !f.hasLoadMovie && !f.hasOnClipEvent)
+    .filter((f) => !f.file.includes('test_game'))
+    .sort((a, b) => b.score - a.score || a.lines - b.lines)
+    .slice(0, 5)
+    .map((f) => ({
+      file: f.file,
+      score: f.score,
+      lines: f.lines,
+      classes: f.classes,
+      extends: f.extends,
+      importsCount: f.imports.length,
+      hasXml: f.hasXml,
+      reasons: f.reasons,
+    }));
+
+  const payload = {
+    generatedAt: new Date().toISOString(),
+    strategy: 'Haxe-first migration: select low-Flash-dependency business logic modules',
+    sourceInventory: path.relative(ROOT, INVENTORY_PATH),
+    candidates,
+  };
+
+  fs.mkdirSync(path.dirname(OUTPUT_JSON), { recursive: true });
+  fs.writeFileSync(OUTPUT_JSON, JSON.stringify(payload, null, 2) + '\n', 'utf8');
+
+  const lines = [
+    '# MVP Lot A — Modules candidats (Haxe first)',
+    '',
+    `Généré le: ${payload.generatedAt}`,
+    '',
+    'Ces 5 modules sont les meilleurs candidats initiaux pour le portage Haxe (faible dépendance runtime Flash).',
+    '',
+    '| Module | Score | Lignes | Classes | XML | Notes |',
+    '|---|---:|---:|---|---|---|',
+    ...candidates.map((c) =>
+      `| \`${c.file}\` | ${c.score} | ${c.lines} | ${c.classes.join(', ') || '-'} | ${c.hasXml ? 'Oui' : 'Non'} | ${c.reasons.join('; ')} |`
+    ),
+    '',
+    '## Test rapide',
+    '',
+    '```bash',
+    'node tools/migration/inventory_as2.js',
+    'node tools/migration/select_lot_a.js',
+    '```',
+    '',
+    'Si ces modules vous conviennent, on peut démarrer le portage Haxe du premier module dès l’étape suivante.',
+  ];
+
+  fs.writeFileSync(OUTPUT_MD, lines.join('\n') + '\n', 'utf8');
+
+  console.log(`Lot A candidates written to ${path.relative(ROOT, OUTPUT_JSON)}`);
+  console.log(`MVP report written to ${path.relative(ROOT, OUTPUT_MD)}`);
+}
+
+main();


### PR DESCRIPTION
### Motivation

- Provide a progressive migration path off legacy ActionScript/Flash with a minimal-impact, testable Haxe -> TypeScript/Node strategy. 
- Enable early verification by compiling/instantiating a set of low-runtime-dependency modules and running them on Node without the SWF runtime.

### Description

- Add a high-level migration plan (`MIGRATION_PLAN.md`) and step-by-step guides (`docs/STEP_BY_STEP_HAXE_TO_TS.md`, `docs/COMMENT_TESTER.md`) to run an MVP flow. 
- Introduce automatic AS2 inventory and Lot A selector tooling under `tools/migration/` and outputs in `migration/inventory/` (`as2-inventory.json`, `lot-a-candidates.json`) and report docs (`docs/MVP_LOT_A.md`, `docs/LOT_A_PROGRESS.md`).
- Port a large subset of core logic to Haxe under `packages/core-haxe/src/frutiparc/core/` (many modules such as `CBee`, `CBeeLocal`, `CBeeManager`, `ClassLoader`, `FE*`, `FileLoader`, `Slot*`, `User*`, `Win*`, etc.) to form a Haxe-first migration kernel.
- Add Node-side runtime JS mirrors of the same pragmatic subset under `packages/core-js/src/` so the migrated modules can be executed and tested immediately (e.g. `cbee.js`, `cbeeLocal.js`, `classLoader.js`, `feString.js`, `feColor.js`, `http.js`, `statusMng.js`, `mvpShowcase.js`, etc.).
- Add a small HTTP MVP endpoint in `server.js` at `GET /api/mvp/showcase` to return a sample payload from migrated modules.
- Add comprehensive parity/unit tests exercising the migrated modules under `tests/migration/*.spec.js` and helper scripts (`tools/migration/run_mvp.sh`) to automate inventory + Lot A selection.
- Update `README.md` with instructions to run the server and how to exercise the Node MVP endpoint.

### Testing

- Unit/migration test suite was executed with Node's test runner using `node --test tests/migration/*.spec.js` (the repository includes the exact invocation in `docs/LOT_A_PROGRESS.md`) and all tests in `tests/migration/` passed.
- Manual smoke: the MVP endpoint returns the composed showcase JSON and can be exercised with `curl http://localhost:8888/api/mvp/showcase` after `npm start` of the server.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c94b569c9c832096167350726250a7)