### PR TITLE
Add fetch/XHR interceptor to rewrite frutiparc.com URLs client-side

### DIFF
--- a/public/ruffle.html
+++ b/public/ruffle.html
@@ -19,6 +19,7 @@
                 'www.frutiparc.com':      'http://localhost:8888',
                 'swf.beta.frutiparc.com': 'http://localhost:8888/swf',
                 'swf.frutiparc.com':      'http://localhost:8888/swf',
+                'localhost:5173':         'http://localhost:8888',     // SWF uses CBee port for HTTP — redirect
             };
 
             window.fetch = function(input, init) {

--- a/public/ruffle.html
+++ b/public/ruffle.html
@@ -3,16 +3,89 @@
 <head>
     <meta charset="UTF-8">
     <title>Frutiparc — Ruffle</title>
-    <script src="https://unpkg.com/@ruffle-rs/ruffle"></script>
     <style>
         body { margin: 0; background: #335511; display: flex; justify-content: center; align-items: center; min-height: 100vh; }
         #player-container { width: 1024px; height: 768px; }
     </style>
+
+    <!-- Intercept fetch() BEFORE Ruffle loads so WASM picks up our override -->
+    <script>
+        (function() {
+            const _origFetch = window.fetch;
+
+            // Map original Frutiparc domains → local server paths
+            const domainMap = {
+                'www.beta.frutiparc.com': 'http://localhost:8888',
+                'www.frutiparc.com':      'http://localhost:8888',
+                'swf.beta.frutiparc.com': 'http://localhost:8888/swf',
+                'swf.frutiparc.com':      'http://localhost:8888/swf',
+            };
+
+            window.fetch = function(input, init) {
+                let url = (typeof input === 'string') ? input : (input instanceof Request ? input.url : String(input));
+
+                // Rewrite frutiparc.com URLs to localhost
+                try {
+                    const parsed = new URL(url);
+                    const host = parsed.hostname + (parsed.port ? ':' + parsed.port : '');
+                    for (const [domain, target] of Object.entries(domainMap)) {
+                        if (host === domain || parsed.hostname === domain) {
+                            const newUrl = target + parsed.pathname + parsed.search;
+                            console.log('[FETCH rewrite]', url, '→', newUrl);
+                            return _origFetch.call(this, newUrl, init);
+                        }
+                    }
+                } catch(e) { /* not a valid absolute URL, pass through */ }
+
+                // Also rewrite prefix-based URLs from SWF patching
+                const prefixRewrites = [
+                    ['/betawww/', '/'],
+                    ['/betaswf/', '/swf/'],
+                    ['/sw/', '/swf/'],
+                ];
+                try {
+                    const parsed = new URL(url);
+                    if (parsed.hostname === 'localhost') {
+                        for (const [prefix, replacement] of prefixRewrites) {
+                            if (parsed.pathname.startsWith(prefix)) {
+                                parsed.pathname = replacement + parsed.pathname.substring(prefix.length);
+                                const newUrl = parsed.toString();
+                                console.log('[FETCH prefix]', url, '→', newUrl);
+                                return _origFetch.call(this, newUrl, init);
+                            }
+                        }
+                    }
+                } catch(e) { /* pass through */ }
+
+                console.log('[FETCH]', url);
+                return _origFetch.call(this, input, init);
+            };
+
+            // Also intercept XMLHttpRequest (some Ruffle code paths may use it)
+            const _origXHROpen = XMLHttpRequest.prototype.open;
+            XMLHttpRequest.prototype.open = function(method, url, ...rest) {
+                let rewritten = url;
+                try {
+                    const parsed = new URL(url, window.location.origin);
+                    const host = parsed.hostname + (parsed.port ? ':' + parsed.port : '');
+                    for (const [domain, target] of Object.entries(domainMap)) {
+                        if (host === domain || parsed.hostname === domain) {
+                            rewritten = target + parsed.pathname + parsed.search;
+                            console.log('[XHR rewrite]', url, '→', rewritten);
+                            break;
+                        }
+                    }
+                } catch(e) {}
+                return _origXHROpen.call(this, method, rewritten, ...rest);
+            };
+        })();
+    </script>
+
+    <script src="https://unpkg.com/@ruffle-rs/ruffle"></script>
 </head>
 <body>
     <div id="player-container"></div>
     <script>
-        // Use Ruffle's JavaScript API for full control over config & networking
         window.addEventListener("DOMContentLoaded", async () => {
             const ruffle = window.RufflePlayer.newest();
             const player = ruffle.createPlayer();
@@ -27,7 +100,7 @@
                 quality: "high",
                 parameters: {
                     sid: "debug",
-                    domain: "localhost:8888/betawww/"
+                    domain: "localhost:8888/"
                 },
                 socketProxy: [
                     { host: "localhost", port: 5173, proxyUrl: "ws://localhost:8888" }

--- a/public/xml/services.xml
+++ b/public/xml/services.xml
@@ -1,3 +1,3 @@
-<services host="localhost">
+<services host="localhost:8888">
 	<service name="frutichat" port="5173" />
 </services>

--- a/server.js
+++ b/server.js
@@ -16,21 +16,19 @@ app.use((req, res, next) => {
 });
 
 // ── Strip SWF domain-shim prefixes ──
-// The patched SWF replaces hardcoded domains with localhost:8888/<prefix>
-// so that every replacement is the exact same byte-length as the original.
-//   www.beta.frutiparc.com  (22) → localhost:8888/betawww (22)
-//   swf.beta.frutiparc.com  (22) → localhost:8888/betaswf (22)
-//   swf.frutiparc.com       (17) → localhost:8888/sw      (17)
-// This middleware strips the prefix so the rest of the server sees clean paths.
+// The patched SWF replaces hardcoded domains with localhost:8888/<prefix>.
+// The JS fetch interceptor in ruffle.html may also rewrite to /swf/<path>.
+// This middleware normalises all variants so the rest of the server sees clean paths.
 app.use((req, res, next) => {
+  // Prefix-based shims from SWF patching
   if (req.url.startsWith('/betawww/') || req.url === '/betawww') {
-    req.url = req.url.substring(8) || '/';           // strip '/betawww'
+    req.url = req.url.substring(8) || '/';
   } else if (req.url.startsWith('/betaswf/') || req.url === '/betaswf') {
-    req.url = req.url.substring(8) || '/';           // strip '/betaswf'
+    req.url = req.url.substring(8) || '/';
   } else if (req.url.startsWith('/sw/') || req.url === '/sw') {
-    req.url = req.url.substring(3) || '/';           // strip '/sw'
+    req.url = req.url.substring(3) || '/';
   }
-  // Also collapse any residual double slashes
+  // Collapse any residual double slashes
   if (req.url.includes('//')) {
     req.url = req.url.replace(/\/{2,}/g, '/');
   }
@@ -328,12 +326,25 @@ app.post('/h/send_debug', (req, res) => {
 });
 
 // ─────────────────────────────────────────────
+// Serve SWF assets under /swf/* (used by the JS fetch interceptor rewrite)
+// ─────────────────────────────────────────────
+app.use('/swf', express.static(path.join(__dirname, 'public', 'swf')));
+
+// ─────────────────────────────────────────────
 // Serve static files AFTER API routes so our endpoints take priority
 // ─────────────────────────────────────────────
 app.use(express.static(path.join(__dirname, 'public')));
 // Fallback: swf.frutiparc.com URLs resolve to root paths (/wheel/wheel1.swf)
 // but files live under public/swf/. This second mount acts as fallback.
 app.use(express.static(path.join(__dirname, 'public', 'swf')));
+
+// ─────────────────────────────────────────────
+// Catch-all 404 with logging (helps diagnose missing assets)
+// ─────────────────────────────────────────────
+app.use((req, res) => {
+  console.log(`[404]   ${req.method} ${req.url}`);
+  res.status(404).type('text/plain').send('Not found');
+});
 
 // ─────────────────────────────────────────────
 // Health check


### PR DESCRIPTION
The core issue: Ruffle's WASM fetch may not work correctly with prefix-patched URLs. New approach: intercept window.fetch and XMLHttpRequest.open BEFORE Ruffle loads, rewriting any URL targeting *.frutiparc.com to localhost:8888 (with /swf/ prefix for asset domains).

This dual-layer approach (JS interceptor + SWF prefix patching) ensures network requests work regardless of how Ruffle constructs/sends URLs.

Also:
- Add /swf/* Express route for interceptor-rewritten asset URLs
- Add catch-all 404 handler with logging for diagnosing missing files
- Keep SWF prefix patches as fallback

https://claude.ai/code/session_01MbPYpqKCRnjpqPmbbraBE5