### PR TITLE
Improve CBee bootstrap handshake for Ruffle startup

### DIFF
--- a/server.js
+++ b/server.js
@@ -588,6 +588,25 @@ function formatDateTime(d) {
   return d.toISOString().replace('T', ' ').substring(0, 19);
 }
 
+function buildChannelListXml() {
+  let inner = '';
+  for (const [name, ch] of Object.entries(channels)) {
+    inner += `<g g="${name}"><t>${ch.topic}</t></g>`;
+  }
+  return `<${CMD.channellist}>${inner}</${CMD.channellist}>`;
+}
+
+function sendBootSequence(socket, client) {
+  const ipAddr = socket.remoteAddress || '127.0.0.1';
+  const username = client?.username || 'Angelisium';
+  const user = users[username] || users['Angelisium'];
+  sendToClient(socket, `<${CMD.ip}>${ipAddr}</${CMD.ip}>`);
+  sendToClient(socket, `<${CMD.time}>${formatDateTime(new Date())}</${CMD.time}>`);
+  sendToClient(socket, `<${CMD.ident} l="${username}" x="${user.xp || 0}" f="${user.fbouille || '000503000000111010'}" />`);
+  sendToClient(socket, `<${CMD.serviceinfo} />`);
+  sendToClient(socket, buildChannelListXml());
+}
+
 // ─────────────────────────────────────────────
 // Handle a single CBee XML message from a client
 // ─────────────────────────────────────────────
@@ -659,6 +678,7 @@ function handleCBeeMessage(socket, rawXml) {
         const xp = user ? user.xp : 10000;
         const fbouille = user ? user.fbouille : '000503000000111010';
         sendToClient(socket, `<${CMD.ident} l="${client.username}" x="${xp}" f="${fbouille}" />`);
+        sendToClient(socket, `<${CMD.serviceinfo} />`);
         console.log(`[CBee]  User "${client.username}" logged in`);
       } else {
         // Failure
@@ -669,11 +689,7 @@ function handleCBeeMessage(socket, rawXml) {
 
     // ── channellist: list available channels ──
     case 'channellist': {
-      let inner = '';
-      for (const [name, ch] of Object.entries(channels)) {
-        inner += `<g g="${name}"><t>${ch.topic}</t></g>`;
-      }
-      sendToClient(socket, `<${CMD.channellist}>${inner}</${CMD.channellist}>`);
+      sendToClient(socket, buildChannelListXml());
       break;
     }
 
@@ -882,12 +898,12 @@ const xmlSocketServer = net.createServer((socket) => {
     buffer: '',
   });
 
-  // Auto-send IP echo — the SWF expects this right after connect
-  const ipAddr = socket.remoteAddress || '127.0.0.1';
-  sendToClient(socket, `<${CMD.ip}>${ipAddr}</${CMD.ip}>`);
-  console.log(`[CBee]  -> Sent IP: ${ipAddr}`);
+  // Auto-send bootstrap frames. In sidAutoInit mode some clients won't
+  // explicitly emit <k /> before waiting for initial state.
+  sendBootSequence(socket, xmlSocketClients.get(socket));
+  console.log('[CBee]  -> Sent boot sequence (ip/time/ident/serviceinfo/channellist)');
 
-  // Auto-send ident response (sidAutoInit mode: the SWF won't send ident itself)
+  // Keep delayed ident for compatibility with slower SWF init paths.
   setTimeout(() => {
     sendToClient(socket,
       `<${CMD.ident} l="${defaultUser}" x="${user.xp}" f="${user.fbouille}" />`


### PR DESCRIPTION
### Motivation
- Ruffle + the legacy SWF can stall on the "connexion au serveur en cours" step because the client expects a richer initial XMLSocket handshake than just `ip`/`time` frames.
- The server should proactively emit the startup frames the SWF often waits for so the UI can progress during reverse-engineering and testing.

### Description
- Added a reusable `buildChannelListXml()` helper to generate the `<channellist>` response from `channels` and used it in the `channellist` handler.
- Added `sendBootSequence(socket, client)` which emits `ip`, `time`, `ident`, `serviceinfo` and `channellist` immediately on new XMLSocket connections to provide a fuller initial state to clients.
- Emit `serviceinfo` immediately after a successful `ident` to better match legacy client startup expectations.
- Kept the existing delayed auto-ident fallback (100ms) for compatibility with slower SWF init paths.
- Changes made in `server.js` (CBee/XMLSocket handling and helper functions).

### Testing
- Performed a static syntax check with `node --check server.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc346622308320a975974803341abf)