### PR TITLE
XMLSocket: dynamic port, improved handshake, and session/session/IP handling

### DIFF
--- a/server.js
+++ b/server.js
@@ -45,7 +45,7 @@ app.use((req, res, next) => {
 });
 
 const port = process.env.PORT || 8888;
-const XMLSOCKET_PORT = 5173; // Port for the CBee XMLSocket server
+const XMLSOCKET_PORT = Number(process.env.XMLSOCKET_PORT || 5000); // Port for the CBee XMLSocket server
 
 // ─────────────────────────────────────────────
 // Helpers: base62 encode/decode (matches FEString/FENumber in AS2)
@@ -180,6 +180,13 @@ app.get('/do/init', (req, res) => {
 // ─────────────────────────────────────────────
 app.get('/do/prefdef', (req, res) => {
   res.type('text/plain').send(`PrefDef=${buildPrefDefString()}`);
+});
+
+// Keep the advertised service port aligned with the live XMLSocket port.
+app.get('/xml/services.xml', (req, res) => {
+  res.type('text/xml').send(
+    `<services host="localhost"><service name="frutichat" port="${XMLSOCKET_PORT}" /></services>`
+  );
 });
 
 // ─────────────────────────────────────────────
@@ -588,6 +595,32 @@ function formatDateTime(d) {
   return d.toISOString().replace('T', ' ').substring(0, 19);
 }
 
+function normalizeClientIp(rawIp) {
+  if (!rawIp) return '127.0.0.1';
+  if (rawIp === '::1') return '127.0.0.1';
+  if (rawIp.startsWith('::ffff:')) return rawIp.substring(7);
+  return rawIp;
+}
+
+function buildChannelListXml() {
+  let inner = '';
+  for (const [name, ch] of Object.entries(channels)) {
+    inner += `<g g="${name}"><t>${ch.topic}</t></g>`;
+  }
+  return `<${CMD.channellist}>${inner}</${CMD.channellist}>`;
+}
+
+function sendBootSequence(socket, client) {
+  const ipAddr = normalizeClientIp(socket.remoteAddress);
+  const username = client?.username || 'Angelisium';
+  const user = users[username] || users['Angelisium'];
+  sendToClient(socket, `<${CMD.ip}>${ipAddr}</${CMD.ip}>`);
+  sendToClient(socket, `<${CMD.time}>${formatDateTime(new Date())}</${CMD.time}>`);
+  sendToClient(socket, `<${CMD.ident} l="${username}" x="${user.xp || 0}" f="${user.fbouille || '000503000000111010'}" />`);
+  sendToClient(socket, `<${CMD.serviceinfo} />`);
+  sendToClient(socket, buildChannelListXml());
+}
+
 // ─────────────────────────────────────────────
 // Handle a single CBee XML message from a client
 // ─────────────────────────────────────────────
@@ -602,7 +635,7 @@ function handleCBeeMessage(socket, rawXml) {
   switch (cmdName) {
     // ── ip: client requests its IP ──
     case 'ip': {
-      const ipAddr = socket.remoteAddress || '127.0.0.1';
+      const ipAddr = normalizeClientIp(socket.remoteAddress);
       sendToClient(socket, `<${CMD.ip}>${ipAddr}</${CMD.ip}>`);
       break;
     }
@@ -624,8 +657,15 @@ function handleCBeeMessage(socket, rawXml) {
       const login = msg.attrs.l;
       const sid = msg.attrs.s;
 
+      // In sidAutoInit mode (e.g. sid=debug from the loader page), the SWF
+      // may skip /do/init and still send ident with a sid.
+      // Create a transient session so ident can succeed.
+      if (sid && !sessions[sid]) {
+        sessions[sid] = { user: null, createdAt: Date.now(), transient: true };
+      }
+
       // Link session to socket
-      if (sid && sessions[sid]) {
+      if (sid) {
         sessions[sid].user = login || sessions[sid].user;
       }
 
@@ -645,20 +685,22 @@ function handleCBeeMessage(socket, rawXml) {
         };
       }
 
-      const user = login ? users[login] : null;
+      const resolvedLogin = login || (sid && sessions[sid] && sessions[sid].user) || 'Angelisium';
+      const user = users[resolvedLogin] || users['Angelisium'];
 
-      if (user || (sid && sessions[sid])) {
+      if (sid || user) {
         // Success: send ident response with user data
-        client.username = login || 'Guest';
+        client.username = resolvedLogin;
         client.sid = sid;
         client.logged = true;
-        if (sid && sessions[sid]) {
+        if (sid) {
           sessions[sid].user = client.username;
         }
 
         const xp = user ? user.xp : 10000;
         const fbouille = user ? user.fbouille : '000503000000111010';
         sendToClient(socket, `<${CMD.ident} l="${client.username}" x="${xp}" f="${fbouille}" />`);
+        sendToClient(socket, `<${CMD.serviceinfo} />`);
         console.log(`[CBee]  User "${client.username}" logged in`);
       } else {
         // Failure
@@ -669,11 +711,7 @@ function handleCBeeMessage(socket, rawXml) {
 
     // ── channellist: list available channels ──
     case 'channellist': {
-      let inner = '';
-      for (const [name, ch] of Object.entries(channels)) {
-        inner += `<g g="${name}"><t>${ch.topic}</t></g>`;
-      }
-      sendToClient(socket, `<${CMD.channellist}>${inner}</${CMD.channellist}>`);
+      sendToClient(socket, buildChannelListXml());
       break;
     }
 
@@ -882,12 +920,12 @@ const xmlSocketServer = net.createServer((socket) => {
     buffer: '',
   });
 
-  // Auto-send IP echo — the SWF expects this right after connect
-  const ipAddr = socket.remoteAddress || '127.0.0.1';
-  sendToClient(socket, `<${CMD.ip}>${ipAddr}</${CMD.ip}>`);
-  console.log(`[CBee]  -> Sent IP: ${ipAddr}`);
+  // Auto-send bootstrap frames. In sidAutoInit mode some clients won't
+  // explicitly emit <k /> before waiting for initial state.
+  sendBootSequence(socket, xmlSocketClients.get(socket));
+  console.log('[CBee]  -> Sent boot sequence (ip/time/ident/serviceinfo/channellist)');
 
-  // Auto-send ident response (sidAutoInit mode: the SWF won't send ident itself)
+  // Keep delayed ident for compatibility with slower SWF init paths.
   setTimeout(() => {
     sendToClient(socket,
       `<${CMD.ident} l="${defaultUser}" x="${user.xp}" f="${user.fbouille}" />`


### PR DESCRIPTION
### Motivation

- Make the advertised XMLSocket service port configurable at runtime so clients receive the correct port when the server is run with a custom port.
- Improve the CBee XMLSocket handshake to be more robust to loader/SWF behavior that may skip `do/init` or expected initial frames, and to normalize client IPs for consistent reporting.
- Centralize channel list construction and streamline ident/session linking so transient sids and automatic logins work reliably.

### Description

- Read `XMLSOCKET_PORT` from the environment via `Number(process.env.XMLSOCKET_PORT || 5000)` and add an endpoint `GET /xml/services.xml` that advertises the running XMLSocket port in a small XML payload.
- Add helper functions `normalizeClientIp`, `buildChannelListXml`, and `sendBootSequence` to normalize IPv6/IPv4-mapped addresses, produce channel list XML, and emit the initial boot frames (`ip`, `time`, `ident`, `serviceinfo`, and `channellist`) on connect.
- Update ident handling to create transient sessions when a `sid` is provided but missing, resolve the effective login username (`resolvedLogin`) from `l` or session, and always emit `serviceinfo` on successful ident; refactor `channellist` handling to use the `buildChannelListXml` helper.
- Replace the prior single ip echo at socket connect with a full boot sequence emission and keep the delayed auto-ident for compatibility with slower SWF init paths.

### Testing

- Ran the existing automated test suite with `npm test` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc346622308320a975974803341abf)