### PR TITLE
Make XMLSocket port configurable, normalize client IPs, and improve CBee boot/login flow

### DIFF
--- a/server.js
+++ b/server.js
@@ -45,7 +45,8 @@ app.use((req, res, next) => {
 });
 
 const port = process.env.PORT || 8888;
-const XMLSOCKET_PORT = 5173; // Port for the CBee XMLSocket server
+const XMLSOCKET_PORT = Number(process.env.XMLSOCKET_PORT || 5000); // Port for the CBee XMLSocket server
+const SERVER_BUILD = process.env.SERVER_BUILD || 'codex-ruffle-debug-v4';
 
 // ─────────────────────────────────────────────
 // Helpers: base62 encode/decode (matches FEString/FENumber in AS2)
@@ -180,6 +181,13 @@ app.get('/do/init', (req, res) => {
 // ─────────────────────────────────────────────
 app.get('/do/prefdef', (req, res) => {
   res.type('text/plain').send(`PrefDef=${buildPrefDefString()}`);
+});
+
+// Keep the advertised service port aligned with the live XMLSocket port.
+app.get('/xml/services.xml', (req, res) => {
+  res.type('text/xml').send(
+    `<services host="localhost"><service name="frutichat" port="${XMLSOCKET_PORT}" /></services>`
+  );
 });
 
 // ─────────────────────────────────────────────
@@ -359,6 +367,7 @@ app.get('/healthz', (req, res) => {
 const server = app.listen(port, () => {
   console.log(`[HTTP]  Server running on http://localhost:${port}`);
   console.log(`        Legacy SWF:  http://localhost:${port}/legacy`);
+  console.log(`[BOOT]  Build=${SERVER_BUILD} XMLSOCKET_PORT=${XMLSOCKET_PORT}`);
 });
 
 // ─────────────────────────────────────────────
@@ -588,6 +597,32 @@ function formatDateTime(d) {
   return d.toISOString().replace('T', ' ').substring(0, 19);
 }
 
+function normalizeClientIp(rawIp) {
+  if (!rawIp) return '127.0.0.1';
+  if (rawIp === '::1') return '127.0.0.1';
+  if (rawIp.startsWith('::ffff:')) return rawIp.substring(7);
+  return rawIp;
+}
+
+function buildChannelListXml() {
+  let inner = '';
+  for (const [name, ch] of Object.entries(channels)) {
+    inner += `<g g="${name}"><t>${ch.topic}</t></g>`;
+  }
+  return `<${CMD.channellist}>${inner}</${CMD.channellist}>`;
+}
+
+function sendBootSequence(socket, client) {
+  const ipAddr = normalizeClientIp(socket.remoteAddress);
+  const username = client?.username || 'Angelisium';
+  const user = users[username] || users['Angelisium'];
+  sendToClient(socket, `<${CMD.ip}>${ipAddr}</${CMD.ip}>`);
+  sendToClient(socket, `<${CMD.time}>${formatDateTime(new Date())}</${CMD.time}>`);
+  sendToClient(socket, `<${CMD.ident} l="${username}" x="${user.xp || 0}" f="${user.fbouille || '000503000000111010'}" />`);
+  sendToClient(socket, `<${CMD.serviceinfo} />`);
+  sendToClient(socket, buildChannelListXml());
+}
+
 // ─────────────────────────────────────────────
 // Handle a single CBee XML message from a client
 // ─────────────────────────────────────────────
@@ -602,8 +637,18 @@ function handleCBeeMessage(socket, rawXml) {
   switch (cmdName) {
     // ── ip: client requests its IP ──
     case 'ip': {
-      const ipAddr = socket.remoteAddress || '127.0.0.1';
+      const ipAddr = normalizeClientIp(socket.remoteAddress);
       sendToClient(socket, `<${CMD.ip}>${ipAddr}</${CMD.ip}>`);
+      // Some Ruffle/AVM1 paths never send explicit <k /> (ident) even after
+      // requesting IP/time. Auto-send ident once to avoid login deadlock.
+      if (!client.logged) {
+        const fallbackUser = users[client.username] || users['Angelisium'];
+        sendToClient(
+          socket,
+          `<${CMD.ident} l="${client.username || 'Angelisium'}" x="${fallbackUser.xp || 0}" f="${fallbackUser.fbouille || '000503000000111010'}" />`
+        );
+        sendToClient(socket, `<${CMD.serviceinfo} />`);
+      }
       break;
     }
 
@@ -624,8 +669,15 @@ function handleCBeeMessage(socket, rawXml) {
       const login = msg.attrs.l;
       const sid = msg.attrs.s;
 
+      // In sidAutoInit mode (e.g. sid=debug from the loader page), the SWF
+      // may skip /do/init and still send ident with a sid.
+      // Create a transient session so ident can succeed.
+      if (sid && !sessions[sid]) {
+        sessions[sid] = { user: null, createdAt: Date.now(), transient: true };
+      }
+
       // Link session to socket
-      if (sid && sessions[sid]) {
+      if (sid) {
         sessions[sid].user = login || sessions[sid].user;
       }
 
@@ -645,20 +697,22 @@ function handleCBeeMessage(socket, rawXml) {
         };
       }
 
-      const user = login ? users[login] : null;
+      const resolvedLogin = login || (sid && sessions[sid] && sessions[sid].user) || 'Angelisium';
+      const user = users[resolvedLogin] || users['Angelisium'];
 
-      if (user || (sid && sessions[sid])) {
+      if (sid || user) {
         // Success: send ident response with user data
-        client.username = login || 'Guest';
+        client.username = resolvedLogin;
         client.sid = sid;
         client.logged = true;
-        if (sid && sessions[sid]) {
+        if (sid) {
           sessions[sid].user = client.username;
         }
 
         const xp = user ? user.xp : 10000;
         const fbouille = user ? user.fbouille : '000503000000111010';
         sendToClient(socket, `<${CMD.ident} l="${client.username}" x="${xp}" f="${fbouille}" />`);
+        sendToClient(socket, `<${CMD.serviceinfo} />`);
         console.log(`[CBee]  User "${client.username}" logged in`);
       } else {
         // Failure
@@ -669,11 +723,7 @@ function handleCBeeMessage(socket, rawXml) {
 
     // ── channellist: list available channels ──
     case 'channellist': {
-      let inner = '';
-      for (const [name, ch] of Object.entries(channels)) {
-        inner += `<g g="${name}"><t>${ch.topic}</t></g>`;
-      }
-      sendToClient(socket, `<${CMD.channellist}>${inner}</${CMD.channellist}>`);
+      sendToClient(socket, buildChannelListXml());
       break;
     }
 
@@ -870,7 +920,9 @@ function handleCBeeMessage(socket, rawXml) {
 // Start XMLSocket TCP server
 // ─────────────────────────────────────────────
 const xmlSocketServer = net.createServer((socket) => {
-  console.log(`[CBee]  Client connected from ${socket.remoteAddress}`);
+  const rawIp = socket.remoteAddress || '';
+  const normalizedIp = normalizeClientIp(rawIp);
+  console.log(`[CBee]  Client connected from ${rawIp} (normalized: ${normalizedIp})`);
   const defaultUser = 'Angelisium';
   const user = users[defaultUser];
 
@@ -882,12 +934,12 @@ const xmlSocketServer = net.createServer((socket) => {
     buffer: '',
   });
 
-  // Auto-send IP echo — the SWF expects this right after connect
-  const ipAddr = socket.remoteAddress || '127.0.0.1';
-  sendToClient(socket, `<${CMD.ip}>${ipAddr}</${CMD.ip}>`);
-  console.log(`[CBee]  -> Sent IP: ${ipAddr}`);
+  // Auto-send bootstrap frames. In sidAutoInit mode some clients won't
+  // explicitly emit <k /> before waiting for initial state.
+  sendBootSequence(socket, xmlSocketClients.get(socket));
+  console.log('[CBee]  -> Sent boot sequence (ip/time/ident/serviceinfo/channellist)');
 
-  // Auto-send ident response (sidAutoInit mode: the SWF won't send ident itself)
+  // Keep delayed ident for compatibility with slower SWF init paths.
   setTimeout(() => {
     sendToClient(socket,
       `<${CMD.ident} l="${defaultUser}" x="${user.xp}" f="${user.fbouille}" />`


### PR DESCRIPTION
### Motivation

- Ensure the advertised XMLSocket service port matches the actual TCP listener and can be configured via environment variables.
- Improve compatibility with Ruffle/AVM1 and sidAutoInit loader flows so clients don't deadlock waiting for login state.
- Normalize IPv6/IPv4 addresses for consistent logging and responses.

### Description

- Read `XMLSOCKET_PORT` and `SERVER_BUILD` from environment (`process.env.XMLSOCKET_PORT`, `process.env.SERVER_BUILD`) and use them when starting services and logging; default `XMLSOCKET_PORT` to `5000` and `SERVER_BUILD` to `'codex-ruffle-debug-v4'`.
- Add an HTTP endpoint `GET /xml/services.xml` that advertises the `frutichat` service with the configured `XMLSOCKET_PORT`.
- Add `normalizeClientIp` helper to convert `::1` and `::ffff:` IPv4-mapped addresses to standard IPv4 strings and use it for logging and replies.
- Factor channel listing into `buildChannelListXml` and introduce `sendBootSequence` to send initial frames (`ip`, `time`, `ident`, `serviceinfo`, channellist`) on XMLSocket connect for faster client boot.
- Improve `ident` handling: auto-create transient sessions when an ident contains a `sid` not present in `sessions`, resolve login via `sid` fallback, and auto-send `ident`/`serviceinfo` in some code paths to avoid login deadlocks.
- Wire the WebSocket→TCP bridge and TCP server to use the configured `XMLSOCKET_PORT` and add clearer connection logs including normalized IPs.

### Testing

- Ran the repository test suite with `npm test`; the tests completed successfully.
- Performed a local integration smoke test by launching the server (`node server.js`) and verifying `GET /xml/services.xml` and `GET /do/init` returned expected payloads and that a TCP client could connect to `XMLSOCKET_PORT` and receive the boot sequence; the smoke checks passed.
- Verified WebSocket→TCP bridging manually with `wscat` to ensure WS messages are forwarded to the configured XMLSocket port and that `\0` termination behavior is preserved; the bridge behaved as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc346622308320a975974803341abf)