### PR TITLE
Warn on missing/incomplete frutibouille SWF assets and add troubleshooting notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,12 @@ Games/                Mini-jeux (Burning Kiwi, Kaluga, Frutibandas, etc.)
 Le serveur TCP sur le port `5173` implémente le protocole CBee
 (XML null-terminated) utilisé par le SWF pour le chat, la présence
 et l'authentification.
+
+
+## Dépannage rapide (frutibouilleur)
+
+Si la fenêtre **Ma Frutibouille** affiche des champs à `undefined` ou un aperçu vide, le problème vient généralement des SWF d'assets manquants/incomplets (`public/swf/fbouille/famille*.swf`).
+
+Dans ce dépôt, plusieurs SWF peuvent être des stubs (taille très faible, ex. ~17 bytes) : le client charge bien les URLs en HTTP 200, mais il n'y a pas de contenu exploitable côté Flash/Ruffle pour alimenter les libellés/visuels.
+
+Au démarrage, `server.js` affiche maintenant un diagnostic `[ASSETS]` pour signaler explicitement ce cas.

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const { WebSocketServer } = require('ws');
 const net = require('net');
 const crypto = require('crypto');
 const path = require('path');
+const fs = require('fs');
 
 const app = express();
 
@@ -43,6 +44,46 @@ app.use((req, res, next) => {
   console.log(`[HTTP]  ${req.method} ${req.url}`);
   next();
 });
+
+
+
+// ─────────────────────────────────────────────
+// Diagnostics: validate critical SWF assets are real files (not stubs)
+// ─────────────────────────────────────────────
+function warnIfStubSwfAssets() {
+  const criticalSwfs = [
+    'public/swf/fbouille/famille0.swf',
+    'public/swf/fbouille/famille1.swf',
+    'public/swf/fbouille/famille2.swf',
+    'public/swf/fbouille/famille3.swf',
+    'public/swf/fbouille/famille4.swf',
+    'public/swf/fbouille/famille5.swf',
+    'public/swf/fbouille/famille6.swf',
+    'public/swf/fbouille/famille7.swf',
+    'public/swf/fbouille/famille8.swf',
+  ];
+
+  const stubFiles = [];
+  for (const relPath of criticalSwfs) {
+    const absPath = path.join(__dirname, relPath);
+    try {
+      const st = fs.statSync(absPath);
+      if (st.size <= 32) {
+        stubFiles.push(`${relPath} (${st.size} bytes)`);
+      }
+    } catch {
+      stubFiles.push(`${relPath} (missing)`);
+    }
+  }
+
+  if (stubFiles.length > 0) {
+    console.warn('[ASSETS] Frutibouille assets look incomplete.');
+    console.warn('[ASSETS] The avatar editor may show blank previews / "undefined" labels.');
+    for (const f of stubFiles) {
+      console.warn(`[ASSETS]   - ${f}`);
+    }
+  }
+}
 
 const port = process.env.PORT || 8888;
 const XMLSOCKET_PORT = 5000; // Port for the CBee XMLSocket server (must end in 000 for FrutiChat cmdList)
@@ -414,6 +455,7 @@ const server = app.listen(port, () => {
   console.log(`[HTTP]  Server running on http://localhost:${port}`);
   console.log(`        Legacy SWF:  http://localhost:${port}/legacy`);
   console.log(`[BOOT]  XMLSOCKET_PORT=${XMLSOCKET_PORT}`);
+  warnIfStubSwfAssets();
 });
 
 // ─────────────────────────────────────────────


### PR DESCRIPTION
### Motivation
- The frutibouilleur (avatar editor) can display `undefined` labels and blank previews even when HTTP requests return 200 because the SWF asset files it depends on may be present but are stub-sized or missing. 
- Add a startup diagnostic so the server explicitly notifies when those critical `famille*.swf` assets are incomplete, making that failure mode immediately visible during debugging.

### Description
- Added an assets validation helper `warnIfStubSwfAssets()` in `server.js` that checks critical files under `public/swf/fbouille/famille0..8.swf` and logs warnings when files are missing or unusually small (stub-sized). 
- The helper is invoked at server start and `fs` is imported to perform the checks, producing `[ASSETS]` warnings to explain why the avatar editor may show `undefined`. 
- Documented the issue with a new `Dépannage rapide (frutibouilleur)` section in `README.md` that explains the stub-asset symptom and points to the new startup diagnostic.

### Testing
- Performed a syntax check with `node --check server.js` which completed successfully. 
- Ran a small Node script to `stat` the `famille*.swf` files to verify sizes and confirm the presence of stub-sized files (commands executed and returned sizes as expected). 
- Confirmed the server start path includes a call to `warnIfStubSwfAssets()` so the diagnostic will run on launch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd9022bee08320b06ac5e6e6d4c4e4)