### PR TITLE
Warn on stub SWF assets, add default bouille list and small API fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,12 @@ Games/                Mini-jeux (Burning Kiwi, Kaluga, Frutibandas, etc.)
 Le serveur TCP sur le port `5173` implémente le protocole CBee
 (XML null-terminated) utilisé par le SWF pour le chat, la présence
 et l'authentification.
+
+
+## Dépannage rapide (frutibouilleur)
+
+Si la fenêtre **Ma Frutibouille** affiche des champs à `undefined` ou un aperçu vide, le problème vient généralement des SWF d'assets manquants/incomplets (`public/swf/fbouille/famille*.swf`).
+
+Dans ce dépôt, plusieurs SWF peuvent être des stubs (taille très faible, ex. ~17 bytes) : le client charge bien les URLs en HTTP 200, mais il n'y a pas de contenu exploitable côté Flash/Ruffle pour alimenter les libellés/visuels.
+
+Au démarrage, `server.js` affiche maintenant un diagnostic `[ASSETS]` pour signaler explicitement ce cas.

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const { WebSocketServer } = require('ws');
 const net = require('net');
 const crypto = require('crypto');
 const path = require('path');
+const fs = require('fs');
 
 const app = express();
 
@@ -43,6 +44,46 @@ app.use((req, res, next) => {
   console.log(`[HTTP]  ${req.method} ${req.url}`);
   next();
 });
+
+
+
+// ─────────────────────────────────────────────
+// Diagnostics: validate critical SWF assets are real files (not stubs)
+// ─────────────────────────────────────────────
+function warnIfStubSwfAssets() {
+  const criticalSwfs = [
+    'public/swf/fbouille/famille0.swf',
+    'public/swf/fbouille/famille1.swf',
+    'public/swf/fbouille/famille2.swf',
+    'public/swf/fbouille/famille3.swf',
+    'public/swf/fbouille/famille4.swf',
+    'public/swf/fbouille/famille5.swf',
+    'public/swf/fbouille/famille6.swf',
+    'public/swf/fbouille/famille7.swf',
+    'public/swf/fbouille/famille8.swf',
+  ];
+
+  const stubFiles = [];
+  for (const relPath of criticalSwfs) {
+    const absPath = path.join(__dirname, relPath);
+    try {
+      const st = fs.statSync(absPath);
+      if (st.size <= 32) {
+        stubFiles.push(`${relPath} (${st.size} bytes)`);
+      }
+    } catch {
+      stubFiles.push(`${relPath} (missing)`);
+    }
+  }
+
+  if (stubFiles.length > 0) {
+    console.warn('[ASSETS] Frutibouille assets look incomplete.');
+    console.warn('[ASSETS] The avatar editor may show blank previews / "undefined" labels.');
+    for (const f of stubFiles) {
+      console.warn(`[ASSETS]   - ${f}`);
+    }
+  }
+}
 
 const port = process.env.PORT || 8888;
 const XMLSOCKET_PORT = 5000; // Port for the CBee XMLSocket server (must end in 000 for FrutiChat cmdList)
@@ -122,11 +163,26 @@ function buildPrefDefString() {
   return r;
 }
 
+const DEFAULT_BOUILLE_LIST = [
+  { b: '000503000000111010', n: 'Classique' },
+  { b: '000503000000111011', n: 'Classique 2' },
+  { b: '000503000000111012', n: 'Classique 3' },
+  { b: '010503000000111010', n: 'Capuche claire' },
+  { b: '020503000000111010', n: 'Capuche foncée' },
+  { b: '000403000000111010', n: 'Regard doux' },
+];
+
+function buildBouilleListXml() {
+  return DEFAULT_BOUILLE_LIST
+    .map((o) => `<b b="${escapeXml(o.b)}">${escapeXml(o.n)}</b>`)
+    .join('');
+}
+
 // ─────────────────────────────────────────────
 // File system tree (virtual)
 // b = "messages;inbox;outbox;blackbox;draftbox;disccollector;inventory;mycontact;recyclebin"
 // ─────────────────────────────────────────────
-const FILE_TREE_XML = `<s u="root" n="Bureau" t="desktop" b="messages;inbox;outbox;blackbox;draftbox;disccollector;inventory;mycontact;recyclebin">
+const FILE_TREE_XML = `<s u="root" n="Bureau" t="desktop" m="0" b="messages;inbox;outbox;blackbox;draftbox;disccollector;inventory;mycontact;recyclebin">
   <f u="messages" n="Messages" t="messages">
     <f u="inbox" n="Boîte de réception" t="inbox" />
     <f u="outbox" n="Messages envoyés" t="outbox" />
@@ -266,6 +322,11 @@ app.get('/do/prefsavepartial', (req, res) => {
   res.type('text/plain').send('state=0');
 });
 
+// Legacy preferences form endpoint used by some SWF flows
+app.get('/prefForm', (req, res) => {
+  res.type('text/xml').send('<r />');
+});
+
 // ─────────────────────────────────────────────
 // ENDPOINT: do/onident — Post-identification data
 // Returns XML with kikooz, items, prefs, logs, etc.
@@ -288,7 +349,7 @@ app.get('/do/onident', (req, res) => {
     user.needsBouille = false; // Only force once per session
   }
 
-  const xml = `<r k="${user.kikooz}" p="${now}" i="${items}"${fAttr}><mp>${myPref}</mp><ul></ul><sl></sl><bl></bl></r>`;
+  const xml = `<r k="${user.kikooz}" p="${now}" i="${items}"${fAttr}><mp>${myPref}</mp><ul></ul><sl></sl><bl>${buildBouilleListXml()}</bl></r>`;
 
   res.type('text/xml').send(xml);
 });
@@ -414,6 +475,7 @@ const server = app.listen(port, () => {
   console.log(`[HTTP]  Server running on http://localhost:${port}`);
   console.log(`        Legacy SWF:  http://localhost:${port}/legacy`);
   console.log(`[BOOT]  XMLSOCKET_PORT=${XMLSOCKET_PORT}`);
+  warnIfStubSwfAssets();
 });
 
 // ─────────────────────────────────────────────
@@ -911,7 +973,7 @@ function handleCBeeMessage(socket, rawXml) {
 
     // ── listbouilles: list available avatar parts ──
     case 'listbouilles': {
-      sendToClient(socket, `<${CMD.listbouilles} />`);
+      sendToClient(socket, `<${CMD.listbouilles}>${buildBouilleListXml()}</${CMD.listbouilles}>`);
       break;
     }
 


### PR DESCRIPTION
### Motivation

- Improve diagnostics when small/missing SWF asset stubs cause the avatar editor to show blank previews or `undefined` fields. 
- Provide a default list of avatar presets (bouilles) so legacy SWF flows and the CBee `listbouilles` command return usable options. 
- Add small compatibility endpoints and XML tweaks expected by legacy clients.

### Description

- Add filesystem checks and a `warnIfStubSwfAssets()` diagnostic that logs `[ASSETS]` warnings for missing or very small SWF files under `public/swf/fbouille/` and invoke it on server startup. 
- Introduce `DEFAULT_BOUILLE_LIST` and `buildBouilleListXml()` utilities and use them to populate the `<bl>` element returned by `/do/onident` and the CBee `listbouilles` response. 
- Add a simple legacy endpoint `GET /prefForm` that returns an empty `<r />` XML response. 
- Tweak `FILE_TREE_XML` to include `m="0"` on the root node. 
- Require `fs` and add related imports and logging; keep existing static serving and request logging behavior unchanged.

### Testing

- Started the server with `node server.js` and observed successful startup logs and the `[ASSETS]` diagnostic output when assets are missing. (succeeded)
- Ran automated smoke tests using `curl` against `GET /healthz`, `GET /do/onident`, and `GET /ff/tree` to verify the health endpoint, that `/do/onident` includes a populated `<bl>` with defaults, and that the file-tree XML contains `m="0"`. (succeeded)
- Exercised legacy flows by hitting `GET /prefForm` to confirm it returns `<r />` and verified CBee `listbouilles` now returns the default bouille XML when triggered by the bridge. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd9022bee08320b06ac5e6e6d4c4e4)