### PR TITLE
Add modern frutibouilleur prototype, asset diagnostics and bouille list integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,25 @@ Games/                Mini-jeux (Burning Kiwi, Kaluga, Frutibandas, etc.)
 Le serveur TCP sur le port `5173` implémente le protocole CBee
 (XML null-terminated) utilisé par le SWF pour le chat, la présence
 et l'authentification.
+
+
+## Dépannage rapide (frutibouilleur)
+
+Si la fenêtre **Ma Frutibouille** affiche des champs à `undefined` ou un aperçu vide, le problème vient généralement des SWF d'assets manquants/incomplets (`public/swf/fbouille/famille*.swf`).
+
+Dans ce dépôt, plusieurs SWF peuvent être des stubs (taille très faible, ex. ~17 bytes) : le client charge bien les URLs en HTTP 200, mais il n'y a pas de contenu exploitable côté Flash/Ruffle pour alimenter les libellés/visuels.
+
+Au démarrage, `server.js` affiche maintenant un diagnostic `[ASSETS]` pour signaler explicitement ce cas.
+
+
+## Prototype moderne : frutibouilleur
+
+Un prototype sans Flash est disponible à l'URL :
+- `http://localhost:8888/modern/frutibouilleur/`
+
+Fichiers :
+- `public/modern/frutibouilleur/index.html`
+- `public/modern/frutibouilleur/styles.css`
+- `public/modern/frutibouilleur/app.js`
+
+Objectif : reproduire le workflow de composition de frutibouille (aperçu + code `fbouille`), en attendant une extraction propre des sprites historiques depuis les SWF.

--- a/public/index.html
+++ b/public/index.html
@@ -11,13 +11,18 @@
     .splash p { font-size: 1rem; color: #ADE76B; margin-bottom: 2rem; }
     .splash a { display: inline-block; padding: 1rem 2rem; background: #94DB39; color: #335511; text-decoration: none; font-weight: bold; border-radius: 8px; font-size: 1.1rem; }
     .splash a:hover { background: #ADE76B; }
+    .links { display:flex; gap:12px; justify-content:center; flex-wrap:wrap; }
+    .links a.secondary { background:#dfeec8; color:#2f4d13; }
   </style>
 </head>
 <body>
   <div class="splash">
     <h1>Frutiparc</h1>
     <p>Le site de jeux Flash des années 2000 — émulé avec Ruffle</p>
-    <a href="/legacy">Entrer dans Frutiparc</a>
+    <div class="links">
+      <a href="/legacy">Entrer dans Frutiparc</a>
+      <a class="secondary" href="/modern/frutibouilleur/">Tester le frutibouilleur moderne</a>
+    </div>
   </div>
 </body>
 </html>

--- a/public/modern/frutibouilleur/app.js
+++ b/public/modern/frutibouilleur/app.js
@@ -1,0 +1,188 @@
+const canvas = document.getElementById('avatar');
+const ctx = canvas.getContext('2d');
+const codeInput = document.getElementById('fbouilleCode');
+const controlsRoot = document.getElementById('controls');
+const presetsRoot = document.getElementById('presets');
+
+const PARTS = [
+  { key: 'hood', label: 'Capuche', max: 5 },
+  { key: 'eyes', label: 'Yeux', max: 5 },
+  { key: 'mouth', label: 'Bouche', max: 5 },
+  { key: 'nose', label: 'Nez', max: 4 },
+  { key: 'pattern', label: 'Motif', max: 5 },
+  { key: 'accessory', label: 'Accessoire', max: 4 },
+  { key: 'hoodShade', label: 'Teinte capuche', max: 5 },
+  { key: 'skin', label: 'Peau', max: 5 },
+  { key: 'outline', label: 'Contour', max: 4 },
+];
+
+const STATE = Object.fromEntries(PARTS.map((p) => [p.key, 0]));
+
+const PRESETS = [
+  { name: 'Classique', code: '000503000000111010' },
+  { name: 'Classique 2', code: '000503000000111011' },
+  { name: 'Classique 3', code: '000503000000111012' },
+  { name: 'Capuche claire', code: '010503000000111010' },
+  { name: 'Capuche foncée', code: '020503000000111010' },
+  { name: 'Regard doux', code: '000403000000111010' },
+];
+
+function clamp(v, max) {
+  return Math.max(0, Math.min(max, Number(v) || 0));
+}
+
+function toCode() {
+  return PARTS.map((p) => String(STATE[p.key]).padStart(2, '0')).join('');
+}
+
+function fromCode(code) {
+  if (!/^\d{18}$/.test(code)) return false;
+  PARTS.forEach((p, i) => {
+    const raw = Number(code.slice(i * 2, i * 2 + 2));
+    STATE[p.key] = clamp(raw, p.max);
+  });
+  return true;
+}
+
+function hoodColor() {
+  return ['#9cd65f', '#8acc52', '#78bb44', '#66a739', '#4e8b2e', '#3f7425'][STATE.hood];
+}
+
+function skinColor() {
+  return ['#f7dfb3', '#f2d2a1', '#edc38e', '#dfa978', '#cd8e5f', '#b9764e'][STATE.skin];
+}
+
+function drawAvatar() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  ctx.fillStyle = '#d9f3b2';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  // Capuche
+  ctx.fillStyle = hoodColor();
+  ctx.beginPath();
+  ctx.ellipse(130, 130, 96, 102, 0, 0, Math.PI * 2);
+  ctx.fill();
+
+  // Visage
+  ctx.fillStyle = skinColor();
+  ctx.beginPath();
+  ctx.ellipse(130, 134, 58, 66, 0, 0, Math.PI * 2);
+  ctx.fill();
+
+  // Motif capuche
+  if (STATE.pattern > 0) {
+    ctx.strokeStyle = ['#ffffff','#ffe48a','#ffb6b6','#c6b6ff','#8fd8ff','#f4f4f4'][STATE.pattern];
+    ctx.lineWidth = 5;
+    for (let i = 0; i < STATE.pattern + 1; i++) {
+      ctx.beginPath();
+      ctx.moveTo(70 + i * 18, 62);
+      ctx.lineTo(95 + i * 18, 92);
+      ctx.stroke();
+    }
+  }
+
+  // Yeux
+  const eyeY = 124 - STATE.eyes;
+  ctx.fillStyle = '#2b2b2b';
+  const eyeSize = 4 + STATE.eyes;
+  ctx.beginPath(); ctx.ellipse(108, eyeY, eyeSize, 5, 0, 0, Math.PI * 2); ctx.fill();
+  ctx.beginPath(); ctx.ellipse(152, eyeY, eyeSize, 5, 0, 0, Math.PI * 2); ctx.fill();
+
+  // Nez
+  ctx.strokeStyle = '#a86f50';
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(130, 132);
+  ctx.lineTo(130 + (STATE.nose - 2) * 2, 142 + STATE.nose);
+  ctx.stroke();
+
+  // Bouche
+  ctx.strokeStyle = '#8a3c48';
+  ctx.lineWidth = 3;
+  ctx.beginPath();
+  const smile = STATE.mouth - 2;
+  ctx.arc(130, 158, 16, 0.2 * Math.PI, 0.8 * Math.PI, smile < 0);
+  ctx.stroke();
+
+  // Accessoire
+  if (STATE.accessory > 0) {
+    ctx.fillStyle = ['#fbd1ff', '#ffd07a', '#8fe6ff', '#ffffff', '#ff9ea6'][STATE.accessory];
+    ctx.beginPath();
+    ctx.roundRect(95, 84, 70, 12, 6);
+    ctx.fill();
+  }
+
+  // Contour
+  ctx.strokeStyle = ['#4d6126','#324018','#24300f','#1b250b','#101707'][STATE.outline];
+  ctx.lineWidth = 4;
+  ctx.beginPath();
+  ctx.ellipse(130, 130, 96, 102, 0, 0, Math.PI * 2);
+  ctx.stroke();
+
+  codeInput.value = toCode();
+}
+
+function renderControls() {
+  controlsRoot.innerHTML = '';
+  PARTS.forEach((part) => {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'control';
+
+    const label = document.createElement('label');
+    label.textContent = `${part.label} (${part.max})`;
+
+    const input = document.createElement('input');
+    input.type = 'range';
+    input.min = '0';
+    input.max = String(part.max);
+    input.value = String(STATE[part.key]);
+    input.addEventListener('input', () => {
+      STATE[part.key] = clamp(input.value, part.max);
+      drawAvatar();
+    });
+
+    wrapper.append(label, input);
+    controlsRoot.appendChild(wrapper);
+  });
+}
+
+function renderPresets() {
+  presetsRoot.innerHTML = '';
+  PRESETS.forEach((preset) => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'preset';
+    btn.textContent = `${preset.name} · ${preset.code}`;
+    btn.addEventListener('click', () => {
+      fromCode(preset.code);
+      renderControls();
+      drawAvatar();
+    });
+    presetsRoot.appendChild(btn);
+  });
+}
+
+codeInput.addEventListener('change', () => {
+  if (fromCode(codeInput.value.trim())) {
+    renderControls();
+    drawAvatar();
+  }
+});
+
+document.getElementById('copyBtn').addEventListener('click', async () => {
+  await navigator.clipboard.writeText(codeInput.value);
+});
+
+document.getElementById('randomBtn').addEventListener('click', () => {
+  PARTS.forEach((p) => { STATE[p.key] = Math.floor(Math.random() * (p.max + 1)); });
+  renderControls();
+  drawAvatar();
+});
+
+if (!fromCode(PRESETS[0].code)) {
+  PARTS.forEach((p) => (STATE[p.key] = 0));
+}
+renderControls();
+renderPresets();
+drawAvatar();

--- a/public/modern/frutibouilleur/index.html
+++ b/public/modern/frutibouilleur/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Frutibouilleur (prototype moderne)</title>
+  <link rel="stylesheet" href="./styles.css" />
+</head>
+<body>
+  <main class="layout">
+    <section class="panel preview-panel">
+      <h1>Frutibouilleur (prototype)</h1>
+      <p>
+        Prototype HTML/CSS/Canvas pour remplacer l'éditeur Flash.
+        Les réglages génèrent une chaîne <code>fbouille</code> compatible (9 paires de chiffres).
+      </p>
+      <canvas id="avatar" width="260" height="260" aria-label="Aperçu frutibouille"></canvas>
+      <label class="code-wrap" for="fbouilleCode">
+        Code fbouille
+        <input id="fbouilleCode" type="text" maxlength="18" spellcheck="false" />
+      </label>
+      <div class="actions">
+        <button id="copyBtn" type="button">Copier le code</button>
+        <button id="randomBtn" type="button" class="secondary">Aléatoire</button>
+      </div>
+    </section>
+
+    <section class="panel controls-panel">
+      <h2>Réglages</h2>
+      <div class="grid" id="controls"></div>
+
+      <h3>Presets</h3>
+      <div class="presets" id="presets"></div>
+
+      <p class="hint">
+        Note : en attendant l'extraction sprite-sheet depuis les SWF historiques,
+        ce prototype reproduit la logique de composition avec des primitives Canvas.
+      </p>
+    </section>
+  </main>
+
+  <script src="./app.js"></script>
+</body>
+</html>

--- a/public/modern/frutibouilleur/styles.css
+++ b/public/modern/frutibouilleur/styles.css
@@ -1,0 +1,105 @@
+:root {
+  --bg: #a6db63;
+  --panel: #f2f2f2;
+  --green: #6ea523;
+  --dark: #274010;
+  --accent: #ef9ca7;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: Verdana, sans-serif;
+  color: #1f2b17;
+  background: linear-gradient(#eaf6dd, #bfe68f);
+}
+
+.layout {
+  max-width: 1080px;
+  margin: 24px auto;
+  padding: 0 16px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.panel {
+  background: var(--panel);
+  border-radius: 16px;
+  border: 2px solid #d3d3d3;
+  box-shadow: 0 2px 6px #0000001f;
+  padding: 16px;
+}
+
+.preview-panel p { margin-top: 0; }
+
+canvas {
+  width: 260px;
+  height: 260px;
+  border-radius: 14px;
+  border: 2px solid #9cd65f;
+  display: block;
+  margin: 12px 0;
+  background: #d9f3b2;
+}
+
+.code-wrap { display: block; font-weight: 700; }
+.code-wrap input {
+  margin-top: 6px;
+  width: 100%;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  padding: 10px;
+  border: 1px solid #b8b8b8;
+  border-radius: 10px;
+}
+
+.actions { margin-top: 10px; display: flex; gap: 8px; }
+button {
+  border: none;
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-weight: 700;
+  cursor: pointer;
+  background: var(--green);
+  color: white;
+}
+button.secondary { background: #85987f; }
+button.preset {
+  background: #e9f5da;
+  color: #1f2b17;
+  border: 1px solid #bdd8a1;
+  text-align: left;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.control {
+  background: #fbfbfb;
+  border: 1px solid #e0e0e0;
+  border-radius: 10px;
+  padding: 8px;
+}
+.control label { font-size: 12px; font-weight: 700; display: block; margin-bottom: 4px; }
+.control input { width: 100%; }
+
+.presets {
+  margin-top: 8px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.hint {
+  margin-top: 12px;
+  font-size: 12px;
+  color: #4b5c3e;
+}
+
+@media (max-width: 900px) {
+  .layout { grid-template-columns: 1fr; }
+  canvas { margin-inline: auto; }
+}

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const { WebSocketServer } = require('ws');
 const net = require('net');
 const crypto = require('crypto');
 const path = require('path');
+const fs = require('fs');
 
 const app = express();
 
@@ -43,6 +44,46 @@ app.use((req, res, next) => {
   console.log(`[HTTP]  ${req.method} ${req.url}`);
   next();
 });
+
+
+
+// ─────────────────────────────────────────────
+// Diagnostics: validate critical SWF assets are real files (not stubs)
+// ─────────────────────────────────────────────
+function warnIfStubSwfAssets() {
+  const criticalSwfs = [
+    'public/swf/fbouille/famille0.swf',
+    'public/swf/fbouille/famille1.swf',
+    'public/swf/fbouille/famille2.swf',
+    'public/swf/fbouille/famille3.swf',
+    'public/swf/fbouille/famille4.swf',
+    'public/swf/fbouille/famille5.swf',
+    'public/swf/fbouille/famille6.swf',
+    'public/swf/fbouille/famille7.swf',
+    'public/swf/fbouille/famille8.swf',
+  ];
+
+  const stubFiles = [];
+  for (const relPath of criticalSwfs) {
+    const absPath = path.join(__dirname, relPath);
+    try {
+      const st = fs.statSync(absPath);
+      if (st.size <= 32) {
+        stubFiles.push(`${relPath} (${st.size} bytes)`);
+      }
+    } catch {
+      stubFiles.push(`${relPath} (missing)`);
+    }
+  }
+
+  if (stubFiles.length > 0) {
+    console.warn('[ASSETS] Frutibouille assets look incomplete.');
+    console.warn('[ASSETS] The avatar editor may show blank previews / "undefined" labels.');
+    for (const f of stubFiles) {
+      console.warn(`[ASSETS]   - ${f}`);
+    }
+  }
+}
 
 const port = process.env.PORT || 8888;
 const XMLSOCKET_PORT = 5000; // Port for the CBee XMLSocket server (must end in 000 for FrutiChat cmdList)
@@ -122,11 +163,26 @@ function buildPrefDefString() {
   return r;
 }
 
+const DEFAULT_BOUILLE_LIST = [
+  { b: '000503000000111010', n: 'Classique' },
+  { b: '000503000000111011', n: 'Classique 2' },
+  { b: '000503000000111012', n: 'Classique 3' },
+  { b: '010503000000111010', n: 'Capuche claire' },
+  { b: '020503000000111010', n: 'Capuche foncée' },
+  { b: '000403000000111010', n: 'Regard doux' },
+];
+
+function buildBouilleListXml() {
+  return DEFAULT_BOUILLE_LIST
+    .map((o) => `<b b="${escapeXml(o.b)}">${escapeXml(o.n)}</b>`)
+    .join('');
+}
+
 // ─────────────────────────────────────────────
 // File system tree (virtual)
 // b = "messages;inbox;outbox;blackbox;draftbox;disccollector;inventory;mycontact;recyclebin"
 // ─────────────────────────────────────────────
-const FILE_TREE_XML = `<s u="root" n="Bureau" t="desktop" b="messages;inbox;outbox;blackbox;draftbox;disccollector;inventory;mycontact;recyclebin">
+const FILE_TREE_XML = `<s u="root" n="Bureau" t="desktop" m="0" b="messages;inbox;outbox;blackbox;draftbox;disccollector;inventory;mycontact;recyclebin">
   <f u="messages" n="Messages" t="messages">
     <f u="inbox" n="Boîte de réception" t="inbox" />
     <f u="outbox" n="Messages envoyés" t="outbox" />
@@ -266,6 +322,11 @@ app.get('/do/prefsavepartial', (req, res) => {
   res.type('text/plain').send('state=0');
 });
 
+// Legacy preferences form endpoint used by some SWF flows
+app.get('/prefForm', (req, res) => {
+  res.type('text/plain').send('state=0');
+});
+
 // ─────────────────────────────────────────────
 // ENDPOINT: do/onident — Post-identification data
 // Returns XML with kikooz, items, prefs, logs, etc.
@@ -288,7 +349,7 @@ app.get('/do/onident', (req, res) => {
     user.needsBouille = false; // Only force once per session
   }
 
-  const xml = `<r k="${user.kikooz}" p="${now}" i="${items}"${fAttr}><mp>${myPref}</mp><ul></ul><sl></sl><bl></bl></r>`;
+  const xml = `<r k="${user.kikooz}" p="${now}" i="${items}"${fAttr}><mp><![CDATA[${myPref}]]></mp><ul><!--empty--></ul><sl><!--empty--></sl><bl>${buildBouilleListXml()}</bl></r>`;
 
   res.type('text/xml').send(xml);
 });
@@ -316,8 +377,8 @@ app.get('/ff/tree', (req, res) => {
 // ─────────────────────────────────────────────
 app.get('/ff/ls', (req, res) => {
   const uid = req.query.uid || 'root';
-  // Return an empty folder listing — the SWF will display an empty desktop/contacts
-  res.type('text/xml').send(`<f u="${uid}"></f>`);
+  // Return an empty folder listing with a placeholder node to avoid legacy null-firstChild edge cases
+  res.type('text/xml').send(`<f u="${uid}"><i /></f>`);
 });
 
 // ─────────────────────────────────────────────
@@ -414,6 +475,7 @@ const server = app.listen(port, () => {
   console.log(`[HTTP]  Server running on http://localhost:${port}`);
   console.log(`        Legacy SWF:  http://localhost:${port}/legacy`);
   console.log(`[BOOT]  XMLSOCKET_PORT=${XMLSOCKET_PORT}`);
+  warnIfStubSwfAssets();
 });
 
 // ─────────────────────────────────────────────
@@ -911,7 +973,7 @@ function handleCBeeMessage(socket, rawXml) {
 
     // ── listbouilles: list available avatar parts ──
     case 'listbouilles': {
-      sendToClient(socket, `<${CMD.listbouilles} />`);
+      sendToClient(socket, `<${CMD.listbouilles}>${buildBouilleListXml()}</${CMD.listbouilles}>`);
       break;
     }
 


### PR DESCRIPTION
### Motivation

- Provide a modern, non-Flash prototype of the frutibouilleur avatar editor to allow editing while SWF sprite extraction is pending.  
- Make the server detect and warn about missing or stubbed SWF asset files that produce blank/undefined avatar previews.  
- Improve compatibility with legacy SWF flows by returning a default list of bouille presets and avoiding XML edge-cases that cause null-firstChild issues in Flash code.

### Description

- Add a modern prototype under `public/modern/frutibouilleur/` including `index.html`, `styles.css` and a Canvas-based `app.js` that generates and encodes `fbouille` codes.  
- Update the top-level splash `public/index.html` and `README.md` to link the prototype and document quick troubleshooting for missing `public/swf/fbouille/famille*.swf` assets.  
- Extend `server.js` with an asset diagnostic `warnIfStubSwfAssets()` that logs incomplete/missing SWF files, add `DEFAULT_BOUILLE_LIST` and `buildBouilleListXml()` to provide preset avatar entries, and return that list in `do/onident` and CBee `listbouilles` responses.  
- Small server compatibility fixes: add a `/prefForm` endpoint, change `ff/ls` to return `<f u="..."><i /></f>` to avoid legacy null-firstChild edge cases, and add an `m="0"` attribute to the root `FILE_TREE_XML` node.

### Testing

- No automated tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd9022bee08320b06ac5e6e6d4c4e4)