### PR TITLE
Add default pens, chat timestamps, private PM channels and fix FPFileMng pos handling

### DIFF
--- a/frutiparc/FPFileMng.as
+++ b/frutiparc/FPFileMng.as
@@ -257,7 +257,7 @@ class FPFileMng extends FFileMng{//}
 		inf.date = x.attributes.d;
 		inf.desc = x.firstChild.nodeValue.toString().split("\r\n");
 		inf.parent = x.attributes.f;
-		inf.pos = extra.pos;
+		inf.pos = (extra!=undefined)?extra.pos:undefined;
 		
 		if(inf.type == "folder"){
 			this.tree[inf.uid] = {name: inf.desc[0], type: inf.desc[1],tpl: x.attributes.p,childs:new Array(),parent: inf.parent};

--- a/server.js
+++ b/server.js
@@ -116,6 +116,11 @@ function decode62(s) {
 }
 
 const DEFAULT_BOUILLE_STATE = '000000000000000000000000';
+const ALL_PEN_ITEM_IDS = [315, 316, 317, 318, 319, 320, 321, 322, 323, 324, 325, 326, 327, 599, 600, 601, 602];
+
+function withDefaultPens(items = []) {
+  return Array.from(new Set([...(items || []), ...ALL_PEN_ITEM_IDS]));
+}
 
 function normalizeBouilleState(value) {
   let s = String(value || '').replace(/\D/g, '');
@@ -149,7 +154,7 @@ users['Angelisium'] = {
   xp: 4680000,
   kikooz: 150,
   fbouille: DEFAULT_BOUILLE_STATE,
-  items: [1, 2, 3],
+  items: withDefaultPens([1, 2, 3]),
   gender: 'M',
   birthday: '1990-05-15',
   country: 'FR',
@@ -169,6 +174,13 @@ const prefDefs = [
   { id: 4,  type: 'i', name: 'invite_chat_behavior',     def: encode62(1) },
   { id: 5,  type: 's', name: 'wallpaper',                def: '' },
   { id: 6,  type: 'i', name: 'cache_length',             def: encode62(30) },
+  { id: 7,  type: 'b', name: 'cl_open',                  def: 'Y' },
+  { id: 8,  type: 'b', name: 'win_flMoveAnim',           def: 'Y' },
+  { id: 9,  type: 'b', name: 'ch_dsp_h',                 def: 'Y' },
+  { id: 10, type: 'b', name: 'ch_dsp_join',              def: 'Y' },
+  { id: 11, type: 'b', name: 'ch_dsp_leave',             def: 'Y' },
+  { id: 12, type: 'b', name: 'ch_dsp_kick',              def: 'Y' },
+  { id: 13, type: 'b', name: 'ch_dsp_ban',               def: 'Y' },
 ];
 
 function buildPrefDefString() {
@@ -353,7 +365,7 @@ app.all('/do/eb', (req, res) => {
       xp: 10000,
       kikooz: 50,
       fbouille: DEFAULT_BOUILLE_STATE,
-      items: [],
+      items: withDefaultPens([]),
       gender: 'M',
       birthday: '2000-01-01',
       country: 'FR',
@@ -415,7 +427,8 @@ app.get('/do/onident', (req, res) => {
   const username = (session && session.user) || 'Angelisium';
   const user = users[username] || users['Angelisium'];
 
-  const items = (user.items || []).join(',');
+  user.items = withDefaultPens(user.items);
+  const items = user.items.join(',');
   const myPref = user.prefs || '';
   const now = new Date().toISOString().replace('T', ' ').substring(0, 19);
 
@@ -782,12 +795,34 @@ function broadcastToChannel(channelName, xmlStr, excludeSocket = null) {
   }
 }
 
+function getSocketsForUsername(username) {
+  const sockets = [];
+  for (const [sock, cl] of xmlSocketClients) {
+    if (cl && cl.username === username && cl.logged) {
+      sockets.push(sock);
+    }
+  }
+  return sockets;
+}
+
 function pad2(n) {
   return String(n).padStart(2, '0');
 }
 
 function formatDateTime(d) {
   return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}.${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}`;
+}
+
+function formatChatTimePrefix(d) {
+  return `[${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}] `;
+}
+
+function buildChatTimeAttrs(date = new Date()) {
+  return {
+    h: formatChatTimePrefix(date),
+    // Some legacy paths rebuild "$h" from a raw datetime field.
+    d: formatDateTime(date),
+  };
 }
 
 function normalizeClientIp(rawIp) {
@@ -864,7 +899,7 @@ function handleCBeeMessage(socket, rawXml) {
           xp: 10000,
           kikooz: 50,
           fbouille: DEFAULT_BOUILLE_STATE,
-          items: [],
+          items: withDefaultPens([]),
           gender: 'M',
           birthday: '2000-01-01',
           country: 'FR',
@@ -915,6 +950,8 @@ case 'join': {
     userXml += `<u u="${escapeXml(u)}" x="${ud.xp || 0}" sx="${ud.gender || 'M'}" bd="${ud.birthday || '2000-01-01.00:00:00'}" co="${ud.country || 'FR'}" rg="${ud.region || ''}" p="1" s="00000" mu="0000-00-00 00:00:00" f="${bouilleOf(ud)}" />`;
   }
 
+  const timeAttrs = buildChatTimeAttrs();
+
   // 1. Réponse canonique au join
   sendToClient(
     socket,
@@ -927,7 +964,7 @@ case 'join': {
   // 3. Message système visible dans le chat
   sendToClient(
     socket,
-    `<${CMD.send} u="Serveur" t="m" p="" g="${g}">Vous discutez à présent sur le salon ${escapeXml(channel.desc || g)}</${CMD.send}>`
+    `<${CMD.send} u="Serveur" t="m" p="" g="${g}" h="${timeAttrs.h}" d="${timeAttrs.d}">Vous discutez à présent sur le salon ${escapeXml(channel.desc || g)}</${CMD.send}>`
   );
 
   // 4. Notification légère aux autres
@@ -959,10 +996,11 @@ case 'send': {
   const text = msg.content || '';
   const type = msg.attrs.t || 'm';
   const pen = (msg.attrs.p !== undefined) ? msg.attrs.p : '';
+  const timeAttrs = buildChatTimeAttrs();
 
   if (g && client.logged) {
     const safeText = escapeXml(text);
-    const xml = `<${CMD.send} u="${escapeXml(client.username)}" t="${type}" p="${pen}" g="${g}">${safeText}</${CMD.send}>`;
+    const xml = `<${CMD.send} u="${escapeXml(client.username)}" t="${type}" p="${pen}" g="${g}" h="${timeAttrs.h}" d="${timeAttrs.d}">${safeText}</${CMD.send}>`;
     broadcastToChannel(g, xml);
 } else if (msg.attrs.u) {
   const targetUser = msg.attrs.u;
@@ -971,7 +1009,7 @@ case 'send': {
   // Echo au sender, indispensable pour afficher sa propre ligne
   sendToClient(
     socket,
-    `<${CMD.send} u="${escapeXml(client.username)}" t="${type}" p="${pen}">${safeText}</${CMD.send}>`
+    `<${CMD.send} u="${escapeXml(client.username)}" t="${type}" p="${pen}" h="${timeAttrs.h}" d="${timeAttrs.d}">${safeText}</${CMD.send}>`
   );
 
   // Envoi au destinataire
@@ -979,7 +1017,7 @@ case 'send': {
     if (cl.username === targetUser) {
       sendToClient(
         sock,
-        `<${CMD.send} u="${escapeXml(client.username)}" t="${type}" p="${pen}">${safeText}</${CMD.send}>`
+        `<${CMD.send} u="${escapeXml(client.username)}" t="${type}" p="${pen}" h="${timeAttrs.h}" d="${timeAttrs.d}">${safeText}</${CMD.send}>`
       );
     }
   }
@@ -1058,17 +1096,38 @@ case 'fbouille': {
 
 case 'createchannel': {
   const otherUser = msg.attrs.u || '';
+  const requester = client.username || '';
   const title = msg.content || otherUser || 'Discussion privée';
 
-  if (!otherUser) {
+  if (!otherUser || !requester) {
     sendToClient(socket, `<${CMD.error} />`);
     break;
+  }
+
+  const sortedUsers = [requester.toLowerCase(), otherUser.toLowerCase()].sort();
+  const privateGroup = `pm_${sortedUsers[0]}_${sortedUsers[1]}`;
+  const privatePass = `pw_${sortedUsers[0].slice(0, 4)}_${sortedUsers[1].slice(0, 4)}`;
+
+  if (!channels[privateGroup]) {
+    channels[privateGroup] = {
+      desc: `Discussion privée ${requester}/${otherUser}`,
+      topic: title,
+      users: new Set(),
+      private: true,
+      pass: privatePass,
+    };
   }
 
   // Accusé de réception de l’ouverture de la discussion privée
   sendToClient(
     socket,
-    `<${CMD.createchannel} u="${escapeXml(otherUser)}">${escapeXml(title)}</${CMD.createchannel}>`
+    `<${CMD.createchannel} u="${escapeXml(otherUser)}" g="${privateGroup}" p="${privatePass}">${escapeXml(title)}</${CMD.createchannel}>`
+  );
+
+  // Invite "privée" envoyée au demandeur pour ouvrir immédiatement la box
+  sendToClient(
+    socket,
+    `<${CMD.invitechat} u="${escapeXml(otherUser)}" g="${privateGroup}" p="${privatePass}" />`
   );
 
   // On pousse aussi les infos connues sur l’autre user
@@ -1090,6 +1149,14 @@ case 'createchannel': {
     socket,
     `<${CMD.trace} u="${escapeXml(otherUser)}" p="1" s="00000" mu="0000-00-00 00:00:00" f="${bouilleOf(ud)}" />`
   );
+
+  // Si l'autre utilisateur est connecté, il reçoit aussi l'invitation.
+  for (const targetSock of getSocketsForUsername(otherUser)) {
+    sendToClient(
+      targetSock,
+      `<${CMD.invitechat} u="${escapeXml(requester)}" g="${privateGroup}" p="${privatePass}" />`
+    );
+  }
 
   break;
 }


### PR DESCRIPTION
### Motivation
- Ensure users always have the set of default pen items and stabilize item lists across endpoints and login flows. 
- Provide consistent timestamp metadata for chat lines and introduce a more predictable private-message channel creation flow. 
- Avoid a potential runtime error when `extra` is undefined in file manager `onMake` handling.

### Description
- Added `ALL_PEN_ITEM_IDS` and helper `withDefaultPens()` and applied it to user initialization and endpoints (`/do/eb`, `/do/onident`, CBee `ident`) so `items` always include default pen IDs. 
- Extended `prefDefs` with additional preferences and left `buildPrefDefString()` unchanged to include them. 
- Implemented chat timestamp helpers (`formatChatTimePrefix`, `buildChatTimeAttrs`) and attached `h` and `d` attributes to chat messages on `join`, channel `send`, and private echoes. 
- Added `getSocketsForUsername()` and revamped `createchannel` to create deterministic private group names and passwords, persist channel metadata (`private`, `pass`) and send `invitechat` to both requester and target when available. 
- Fixed ActionScript `onMake` to safely assign `inf.pos` when `extra` may be undefined: `inf.pos = (extra!=undefined)?extra.pos:undefined;`.

### Testing
- Ran the Node test/smoke suite via `npm test` and performed basic API smoke checks for `/do/onident` and `/do/eb`; the suite completed and smoke checks behaved as expected. 
- Verified CBee flows by logging in (`ident`), joining a channel (`join`) and sending messages (`send`) and confirmed timestamp attributes were emitted. 
- Exercised private chat creation (`createchannel`) and validated both sides receive `invitechat` when connected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ced28c7a8883208d034bd5ca5b6793)