### PR TITLE
Add SWF patchers, robust URL shims, and legacy server/chat compatibility fixes

### DIFF
--- a/frutiparc/FPFileMng.as
+++ b/frutiparc/FPFileMng.as
@@ -257,7 +257,7 @@ class FPFileMng extends FFileMng{//}
 		inf.date = x.attributes.d;
 		inf.desc = x.firstChild.nodeValue.toString().split("\r\n");
 		inf.parent = x.attributes.f;
-		inf.pos = extra.pos;
+		inf.pos = (extra!=undefined)?extra.pos:undefined;
 		
 		if(inf.type == "folder"){
 			this.tree[inf.uid] = {name: inf.desc[0], type: inf.desc[1],tpl: x.attributes.p,childs:new Array(),parent: inf.parent};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Backend server for Frutiparc Flash game emulation via Ruffle",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node patch-swf.js && node patch-frusion-swfs.js && node server.js"
   },
   "keywords": [],
   "author": "",

--- a/patch-frusion-swfs.js
+++ b/patch-frusion-swfs.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * Patch Frusion client SWFs in-place so runtime URLs point to the localhost shim.
+ *
+ * This keeps repository history text-only (no committed SWF binaries) while
+ * preserving local dev behavior previously achieved via committed binary edits.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const zlib = require('zlib');
+
+const TARGETS = [
+  'frusion/frusion_client.swf',
+  'public/frusion_client.swf',
+  'public/swf/frusion_client.swf',
+];
+
+const PATCHES = [
+  {
+    from: 'http://www.beta.frutiparc.com/swf/',
+    to: 'http://localhost:8888/betawww/swf/',
+  },
+  {
+    from: 'www.beta.frutiparc.com',
+    to: 'localhost:8888/betawww',
+  },
+];
+
+const mode = process.argv.includes('--check') ? 'check' : 'apply';
+
+function readBody(raw) {
+  const sig = raw.slice(0, 3).toString('ascii');
+  if (sig === 'CWS') {
+    return {
+      sig,
+      header: raw.slice(0, 8),
+      body: zlib.inflateSync(raw.slice(8)),
+    };
+  }
+  if (sig === 'FWS') {
+    return {
+      sig,
+      header: raw.slice(0, 8),
+      body: Buffer.from(raw.slice(8)),
+    };
+  }
+  throw new Error('Invalid SWF signature');
+}
+
+function encodeSwf(sig, header, body) {
+  const newHeader = Buffer.from(header);
+  newHeader.writeUInt32LE(8 + body.length, 4);
+  if (sig === 'CWS') {
+    return Buffer.concat([newHeader, zlib.deflateSync(body)]);
+  }
+  return Buffer.concat([newHeader, body]);
+}
+
+function patchBuffer(body, from, to) {
+  const fromBuf = Buffer.from(from, 'utf8');
+  const toBuf = Buffer.from(to, 'utf8');
+
+  if (fromBuf.length !== toBuf.length) {
+    throw new Error(`Patch length mismatch for "${from}" -> "${to}"`);
+  }
+
+  let patched = 0;
+  let pos = 0;
+  while ((pos = body.indexOf(fromBuf, pos)) !== -1) {
+    toBuf.copy(body, pos);
+    patched++;
+    pos += fromBuf.length;
+  }
+  return patched;
+}
+
+let totalPatched = 0;
+
+for (const relPath of TARGETS) {
+  const filePath = path.resolve(relPath);
+  if (!fs.existsSync(filePath)) {
+    console.warn(`[skip] ${relPath} (missing)`);
+    continue;
+  }
+
+  const raw = fs.readFileSync(filePath);
+  const { sig, header, body } = readBody(raw);
+
+  let filePatched = 0;
+  for (const patch of PATCHES) {
+    filePatched += patchBuffer(body, patch.from, patch.to);
+  }
+
+  totalPatched += filePatched;
+
+  if (filePatched === 0) {
+    console.log(`[ok] ${relPath} (already patched or patterns not found)`);
+    continue;
+  }
+
+  if (mode === 'check') {
+    console.log(`[check] ${relPath} would patch ${filePatched} occurrence(s)`);
+    continue;
+  }
+
+  const backupPath = `${filePath}.original`;
+  if (!fs.existsSync(backupPath)) {
+    fs.copyFileSync(filePath, backupPath);
+  }
+
+  const out = encodeSwf(sig, header, body);
+  fs.writeFileSync(filePath, out);
+  console.log(`[patch] ${relPath} patched ${filePatched} occurrence(s)`);
+}
+
+if (mode === 'check') {
+  console.log(`Done (check mode). Total patchable occurrences: ${totalPatched}`);
+} else {
+  console.log(`Done. Total patched occurrences: ${totalPatched}`);
+}

--- a/patch-swf.js
+++ b/patch-swf.js
@@ -23,19 +23,24 @@ const DST = 'legacy/main.swf';
 const BACKUP = 'legacy/main.swf.original';
 
 // What to replace — each `to` string MUST be the same length as `from`.
-// We pad short replacements with URL path segments that the browser
-// resolves away:  /pad/../  (8 chars, net effect = /)
-//                 /./       (3 chars, net effect = /)
-// This way http://localhost:8888/pad/../xml/foo → http://localhost:8888/xml/foo
+// We pad short replacements with '/./' segments that URL parsers resolve
+// transparently, while keeping a slash right after the host. This avoids
+// malformed concatenations like http://localhost:8888animfrusion.swf.
 const patches = [
-  { from: 'www.beta.frutiparc.com', to: 'localhost:8888/betawww' },  // 22 chars each
-  { from: 'swf.beta.frutiparc.com', to: 'localhost:8888/betaswf' },  // 22 chars each
-  { from: 'swf.frutiparc.com', to: 'localhost:8888/sw' },            // 17 chars each
+  // Original host constants
+  { from: 'www.beta.frutiparc.com', to: 'localhost:8888/./././/' }, // 22 chars each
+  { from: 'swf.beta.frutiparc.com', to: 'localhost:8888/./././/' }, // 22 chars each
+  { from: 'swf.frutiparc.com', to: 'localhost:8888/./' },           // 17 chars each
+  // Migration from previous shim values (already patched files)
+  { from: 'localhost:8888/betawww', to: 'localhost:8888/./././/' }, // 22 chars each
+  { from: 'localhost:8888/betaswf', to: 'localhost:8888/./././/' }, // 22 chars each
+  { from: 'localhost:8888/sw', to: 'localhost:8888/./' },           // 17 chars each
+  // Normalize Frusion loader movie names so host+filename concatenations stay valid
+  { from: 'animfrusion.swf', to: '/animfrusion.sw' },              // 15 chars each
+  { from: 'skinFrusion.swf', to: '/skinFrusion.sw' },              // 15 chars each
 ];
 
 // Each replacement is exactly the same length as the original.
-// The server strips these prefixes (/betawww, /betaswf, /sw) from
-// incoming URLs before routing, so they act as transparent shims.
 
 // ── Bytecode patches ─────────────────────────────────────────────
 // These modify specific AVM1 bytecode values at known offsets in the
@@ -144,4 +149,4 @@ fs.writeFileSync(DST, newSwf);
 
 console.log(`\nDone! ${patchCount} patch(es) applied.`);
 console.log(`New SWF size: ${newSwf.length} bytes`);
-console.log(`\nThe SWF now points to localhost:8888 instead of www.beta.frutiparc.com`);
+console.log(`\nThe SWF now points to localhost:8888 with slash-safe host shims.`);

--- a/public/ruffle.html
+++ b/public/ruffle.html
@@ -37,13 +37,21 @@
                     ? input
                     : (input instanceof Request ? input.url : String(input));
 
+                // Some legacy URL builders concatenate host + file without "/"
+                // (e.g. http://localhost:8888animfrusion.swf). Fix it here.
+                if (typeof url === 'string') {
+                    url = url.replace(/^http:\/\/localhost:8888(?![\/:])/, 'http://localhost:8888/');
+                    url = url.replace(/^https:\/\/localhost:8888(?![\/:])/, 'https://localhost:8888/');
+                }
+
                 try {
                     const parsed = new URL(url);
                     const host = parsed.hostname + (parsed.port ? ':' + parsed.port : '');
 
                     for (const [domain, target] of Object.entries(domainMap)) {
                         if (host === domain || parsed.hostname === domain) {
-                            const newUrl = target + parsed.pathname + parsed.search;
+                            const path = parsed.pathname.startsWith('/') ? parsed.pathname : ('/' + parsed.pathname);
+                            const newUrl = target + path + parsed.search;
                             console.log('[FETCH rewrite]', url, '->', newUrl);
                             return _origFetch.call(this, newUrl, init);
                         }
@@ -78,13 +86,19 @@
             XMLHttpRequest.prototype.open = function(method, url, ...rest) {
                 let rewritten = url;
 
+                if (typeof rewritten === 'string') {
+                    rewritten = rewritten.replace(/^http:\/\/localhost:8888(?![\/:])/, 'http://localhost:8888/');
+                    rewritten = rewritten.replace(/^https:\/\/localhost:8888(?![\/:])/, 'https://localhost:8888/');
+                }
+
                 try {
-                    const parsed = new URL(url, window.location.origin);
+                    const parsed = new URL(rewritten, window.location.origin);
                     const host = parsed.hostname + (parsed.port ? ':' + parsed.port : '');
 
                     for (const [domain, target] of Object.entries(domainMap)) {
                         if (host === domain || parsed.hostname === domain) {
-                            rewritten = target + parsed.pathname + parsed.search;
+                            const path = parsed.pathname.startsWith('/') ? parsed.pathname : ('/' + parsed.pathname);
+                            rewritten = target + path + parsed.search;
                             console.log('[XHR rewrite]', url, '->', rewritten);
                             break;
                         }
@@ -150,7 +164,9 @@
                 quality: "high",
                 parameters: {
                     sid: sid,
-                    domain: "localhost:8888/",
+                    // Keep a slash-stable suffix: some legacy concatenations
+                    // drop one trailing slash before appending filenames.
+                    domain: "localhost:8888/./",
                     s: s,
                     e: e
                 },
@@ -159,7 +175,7 @@
                 ],
                 openUrlMode: "allow",
                 allowNetworking: "all",
-                base: "/"
+                base: "http://localhost:8888/"
             });
         });
     </script>

--- a/server.js
+++ b/server.js
@@ -116,17 +116,18 @@ function decode62(s) {
 }
 
 const DEFAULT_BOUILLE_STATE = '000000000000000000000000';
+const ALL_PEN_ITEM_IDS = [315, 316, 317, 318, 319, 320, 321, 322, 323, 324, 325, 326, 327, 599, 600, 601, 602];
+
+function withDefaultPens(items = []) {
+  return Array.from(new Set([...(items || []), ...ALL_PEN_ITEM_IDS]));
+}
 
 function normalizeBouilleState(value) {
-  let s = String(value || '').replace(/\D/g, '');
+  // Frutibouille uses base62 tokens (0-9, a-z, A-Z), not only digits.
+  let s = String(value || '').replace(/[^0-9a-zA-Z]/g, '');
 
-  if (s.length < 24) s = s.padEnd(24, '0');
+  if (s.length === 0) return DEFAULT_BOUILLE_STATE;
   if (s.length > 24) s = s.slice(0, 24);
-
-  const family = s.slice(0, 2);
-  if (family !== '00' && family !== '01') {
-    s = '00' + s.slice(2);
-  }
 
   return s;
 }
@@ -149,7 +150,7 @@ users['Angelisium'] = {
   xp: 4680000,
   kikooz: 150,
   fbouille: DEFAULT_BOUILLE_STATE,
-  items: [1, 2, 3],
+  items: withDefaultPens([1, 2, 3]),
   gender: 'M',
   birthday: '1990-05-15',
   country: 'FR',
@@ -169,6 +170,13 @@ const prefDefs = [
   { id: 4,  type: 'i', name: 'invite_chat_behavior',     def: encode62(1) },
   { id: 5,  type: 's', name: 'wallpaper',                def: '' },
   { id: 6,  type: 'i', name: 'cache_length',             def: encode62(30) },
+  { id: 7,  type: 'b', name: 'cl_open',                  def: 'Y' },
+  { id: 8,  type: 'b', name: 'win_flMoveAnim',           def: 'Y' },
+  { id: 9,  type: 'b', name: 'ch_dsp_h',                 def: 'Y' },
+  { id: 10, type: 'b', name: 'ch_dsp_join',              def: 'Y' },
+  { id: 11, type: 'b', name: 'ch_dsp_leave',             def: 'Y' },
+  { id: 12, type: 'b', name: 'ch_dsp_kick',              def: 'Y' },
+  { id: 13, type: 'b', name: 'ch_dsp_ban',               def: 'Y' },
 ];
 
 function buildPrefDefString() {
@@ -246,11 +254,23 @@ app.get('/fileIcon.swf', (req, res) => {
 
 
 function sendAvatarFamily(res, fileName) {
-  const absPath = path.join(__dirname, 'public', 'swf', 'fbouille', fileName);
+  let absPath = path.join(__dirname, 'public', 'swf', 'fbouille', fileName);
 
   if (!fs.existsSync(absPath)) {
     console.log(`[SWF]   Missing avatar asset: ${absPath}`);
     return res.status(404).type('text/plain').send('Missing SWF');
+  }
+
+  // Repo snapshot often has a tiny stub for famille1.swf (17 bytes).
+  // Serve famille0 as fallback to avoid malformed SWF parse loops in Ruffle.
+  if (fileName === 'famille1.swf') {
+    try {
+      const st = fs.statSync(absPath);
+      if (st.size <= 32) {
+        console.warn('[SWF]   famille1.swf is a stub, falling back to famille0.swf');
+        absPath = path.join(__dirname, 'public', 'swf', 'fbouille', 'famille0.swf');
+      }
+    } catch {}
   }
 
   console.log(`[SWF]   Serving avatar asset: ${fileName}`);
@@ -353,7 +373,7 @@ app.all('/do/eb', (req, res) => {
       xp: 10000,
       kikooz: 50,
       fbouille: DEFAULT_BOUILLE_STATE,
-      items: [],
+      items: withDefaultPens([]),
       gender: 'M',
       birthday: '2000-01-01',
       country: 'FR',
@@ -365,7 +385,9 @@ app.all('/do/eb', (req, res) => {
   users[username].fbouille = bouille;
 
   console.log(`[do/eb] Saved bouille for ${username}: ${bouille}`);
-  res.type('text/plain').send(`state=0&b=${bouille}&s=${bouille}`);
+  // Legacy callers consume LoadVars here; include k=0 to avoid error.http.undefined
+  // while keeping historical bouille fields.
+  res.type('text/plain').send(`state=0&k=0&b=${bouille}&s=${bouille}&f=${bouille}`);
 });
 
 // ─────────────────────────────────────────────
@@ -415,7 +437,8 @@ app.get('/do/onident', (req, res) => {
   const username = (session && session.user) || 'Angelisium';
   const user = users[username] || users['Angelisium'];
 
-  const items = (user.items || []).join(',');
+  user.items = withDefaultPens(user.items);
+  const items = user.items.join(',');
   const myPref = user.prefs || '';
   const now = new Date().toISOString().replace('T', ' ').substring(0, 19);
 
@@ -438,7 +461,51 @@ app.get('/do/onident', (req, res) => {
 // ─────────────────────────────────────────────
 app.get('/do/ld', (req, res) => {
   const discId = req.query.u || 'unknown';
-  res.type('text/xml').send(`<r u="${discId}" />`);
+  const discMap = {
+    kaluga1: {
+      t: '0',
+      pm: 'single',
+      n: 'kaluga',
+      u: '/swf/games/kaluga/kaluga.swf',
+      p: 'w=700;h=480;m=i',
+      swfList: [
+        '/swf/games/kaluga/kaluga.swf',
+        '/swf/sd/kaluga_tz.swf',
+        '/swf/sd/kaluga_panier.swf',
+      ],
+    },
+    mb21: {
+      t: '0',
+      pm: 'single',
+      n: 'kaluga',
+      u: '/swf/games/kaluga/kaluga.swf',
+      p: 'w=700;h=480;m=i',
+      swfList: [
+        '/swf/games/kaluga/kaluga.swf',
+        '/swf/sd/kaluga_tz.swf',
+        '/swf/sd/kaluga_panier.swf',
+      ],
+    },
+    swapou21: {
+      t: '0',
+      pm: 'single',
+      n: 'kaluga',
+      u: '/swf/games/kaluga/kaluga.swf',
+      p: 'w=700;h=480;m=i',
+      swfList: [
+        '/swf/games/kaluga/kaluga.swf',
+        '/swf/sd/kaluga_tz.swf',
+        '/swf/sd/kaluga_panier.swf',
+      ],
+    },
+  };
+
+  const game = discMap[discId] || discMap.kaluga1;
+  // Legacy loader prepends host on its side; keep <s u> relative to avoid host duplication.
+  const swfNodes = game.swfList.map((u) => `<s u="${u}" />`).join('');
+  res.type('text/xml').send(
+    `<game t="${game.t}" pm="${game.pm}" n="${game.u}" u="${discId}" p="${game.p}">${swfNodes}</game>`
+  );
 });
 
 // ─────────────────────────────────────────────
@@ -455,8 +522,63 @@ app.get('/ff/tree', (req, res) => {
 // ─────────────────────────────────────────────
 app.get('/ff/ls', (req, res) => {
   const uid = req.query.uid || 'root';
+  const sid = req.query.sid;
+  const session = sid ? sessions[sid] : null;
+  const username = (session && session.user) || 'Angelisium';
+  const user = users[username] || users['Angelisium'];
+  const currentBouille = bouilleOf(user);
+  const bouilleBase = `${currentBouille}${DEFAULT_BOUILLE_STATE}`.slice(0, 15);
+  const accessoryTailA = '30x0t0w0D';
+  const accessoryBouilleA = `${bouilleBase}${accessoryTailA}`;
+  if (uid === 'root' || uid === 'desktop') {
+    return res.type('text/xml').send(
+      `<f u="root">
+        <f u="inbox" t="inbox" p="normal" />
+        <f u="disccollector" t="disccollector" />
+        <f u="inventory" t="inventory" />
+        <e u="Gaspard" t="contact" s="10" d="0" a="0">Gaspard@frutiparc.com</e>
+        <f u="mycontact" t="mycontact" />
+        <f u="recyclebin" t="recyclebin" />
+      </f>`
+    );
+  }
+
+  if (uid === 'inventory') {
+    return res.type('text/xml').send(
+      `<f u="inventory">
+        <e u="moutarde" t="wallpaper" s="10" d="0" a="0">Chavelier moutarde
+wal/ch.jpg
+4E5464;</e>
+        <e u="chorale" t="wallpaper" s="10" d="0" a="0">Chorale Frutiparc
+wal/fp.jpg
+ADE76B;</e>
+        <e u="pixiz" t="wallpaper" s="10" d="0" a="0">Pixiz
+wal/pi.jpg
+F9D190;</e>
+        <e u="utopiz" t="wallpaper" s="10" d="0" a="0">Utopiz
+wal/ut.jpg
+F6AFA9;</e>
+        <e u="my_bouille_current" t="bouille" s="10" d="0" a="0">Ma bouille actuelle
+${escapeXml(currentBouille)}</e>
+        <e u="my_bouille_test_1" t="bouille" s="10" d="0" a="0">Accessoire tail 30x0t0w0D
+${escapeXml(accessoryBouilleA)}</e>
+        <e u="my_bouille_test_2" t="bouille" s="10" d="0" a="0">Test bouille #2
+${escapeXml(currentBouille)}</e>
+      </f>`
+    );
+  }
+
+  if (uid === 'disccollector') {
+    return res.type('text/xml').send(
+      `<f u="disccollector">
+        <e u="kaluga1" t="disc" s="10" d="0" a="0">0
+kaluga</e>
+      </f>`
+    );
+  }
+
   // Return an empty folder listing with a placeholder node to avoid legacy null-firstChild edge cases
-  res.type('text/xml').send(`<f u="${uid}"><i /></f>`);
+  return res.type('text/xml').send(`<f u="${uid}"><i /></f>`);
 });
 
 // ─────────────────────────────────────────────
@@ -521,6 +643,11 @@ app.post('/h/send_debug', (req, res) => {
 // ─────────────────────────────────────────────
 // Serve SWF assets under /swf/* (used by the JS fetch interceptor rewrite)
 // ─────────────────────────────────────────────
+// Compatibility aliases for patched legacy Frusion constants (15-char slash-safe names)
+app.get('/animfrusion.sw', (req, res) => res.sendFile(path.join(__dirname, 'public', 'animfrusion.swf')));
+app.get('/skinFrusion.sw', (req, res) => res.sendFile(path.join(__dirname, 'public', 'skinFrusion.swf')));
+
+app.use('/swf/games/kaluga', express.static(path.join(__dirname, 'Games', 'kaluga')));
 app.use('/swf', express.static(path.join(__dirname, 'public', 'swf')));
 
 // ─────────────────────────────────────────────
@@ -782,12 +909,43 @@ function broadcastToChannel(channelName, xmlStr, excludeSocket = null) {
   }
 }
 
+function getSocketsForUsername(username) {
+  const sockets = [];
+  for (const [sock, cl] of xmlSocketClients) {
+    if (cl && cl.username === username && cl.logged) {
+      sockets.push(sock);
+    }
+  }
+  return sockets;
+}
+
+function resolveKnownUsername(nameOrLower) {
+  const raw = String(nameOrLower || '');
+  const low = raw.toLowerCase();
+  for (const known of Object.keys(users)) {
+    if (known.toLowerCase() === low) return known;
+  }
+  return raw;
+}
+
 function pad2(n) {
   return String(n).padStart(2, '0');
 }
 
 function formatDateTime(d) {
   return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}.${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}`;
+}
+
+function formatChatTimePrefix(d) {
+  return `[${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}] `;
+}
+
+function buildChatTimeAttrs(date = new Date()) {
+  return {
+    h: formatChatTimePrefix(date),
+    // Some legacy paths rebuild "$h" from a raw datetime field.
+    d: formatDateTime(date),
+  };
 }
 
 function normalizeClientIp(rawIp) {
@@ -864,7 +1022,7 @@ function handleCBeeMessage(socket, rawXml) {
           xp: 10000,
           kikooz: 50,
           fbouille: DEFAULT_BOUILLE_STATE,
-          items: [],
+          items: withDefaultPens([]),
           gender: 'M',
           birthday: '2000-01-01',
           country: 'FR',
@@ -896,14 +1054,31 @@ case 'join': {
   const g = msg.attrs.g;
 
   if (!channels[g]) {
+    if (String(g).indexOf('pm_') === 0) {
+      const parts = String(g).split('_');
+      const p1 = resolveKnownUsername(parts[1] || '');
+      const p2 = resolveKnownUsername(parts[2] || '');
+      channels[g] = {
+        desc: `Discussion privée ${p1}/${p2}`,
+        topic: `Discussion privée ${p1}/${p2}`,
+        users: new Set([p1, p2].filter(Boolean)),
+        participants: [p1, p2].filter(Boolean),
+        private: true,
+        pass: msg.attrs.p || '',
+      };
+    } else {
     channels[g] = {
       desc: `Salon ${g.charAt(0).toUpperCase()}${g.slice(1)}`,
       topic: `Bienvenue sur le salon ${g} !`,
       users: new Set(),
     };
+    }
   }
 
   const channel = channels[g];
+  if (channel.private && Array.isArray(channel.participants)) {
+    for (const u of channel.participants) channel.users.add(u);
+  }
   channel.users.add(client.username);
   client.channels.add(g);
 
@@ -914,6 +1089,8 @@ case 'join': {
     const ud = users[u] || {};
     userXml += `<u u="${escapeXml(u)}" x="${ud.xp || 0}" sx="${ud.gender || 'M'}" bd="${ud.birthday || '2000-01-01.00:00:00'}" co="${ud.country || 'FR'}" rg="${ud.region || ''}" p="1" s="00000" mu="0000-00-00 00:00:00" f="${bouilleOf(ud)}" />`;
   }
+
+  const timeAttrs = buildChatTimeAttrs();
 
   // 1. Réponse canonique au join
   sendToClient(
@@ -927,7 +1104,7 @@ case 'join': {
   // 3. Message système visible dans le chat
   sendToClient(
     socket,
-    `<${CMD.send} u="Serveur" t="m" p="" g="${g}">Vous discutez à présent sur le salon ${escapeXml(channel.desc || g)}</${CMD.send}>`
+    `<${CMD.send} u="Serveur" t="m" p="" g="${g}" h="${timeAttrs.h}" d="${timeAttrs.d}">Vous discutez à présent sur le salon ${escapeXml(channel.desc || g)}</${CMD.send}>`
   );
 
   // 4. Notification légère aux autres
@@ -938,6 +1115,24 @@ broadcastToChannel(
 );
   break;
 }
+
+    // ── userlist: explicit request for a channel user list ──
+    case 'userlist': {
+      const g = msg.attrs.g || '';
+      const channel = channels[g];
+      if (!channel) {
+        sendToClient(socket, `<${CMD.userlist} g="${g}"></${CMD.userlist}>`);
+        break;
+      }
+      const userArr = Array.from(channel.users || []);
+      let userXml = '';
+      for (const u of userArr) {
+        const ud = users[u] || {};
+        userXml += `<u u="${escapeXml(u)}" x="${ud.xp || 0}" sx="${ud.gender || 'M'}" bd="${ud.birthday || '2000-01-01.00:00:00'}" co="${ud.country || 'FR'}" rg="${ud.region || ''}" p="1" s="00000" mu="0000-00-00 00:00:00" f="${bouilleOf(ud)}" />`;
+      }
+      sendToClient(socket, `<${CMD.userlist} g="${g}">${userXml}</${CMD.userlist}>`);
+      break;
+    }
 
     // ── part: leave a channel ──
     case 'part': {
@@ -959,10 +1154,11 @@ case 'send': {
   const text = msg.content || '';
   const type = msg.attrs.t || 'm';
   const pen = (msg.attrs.p !== undefined) ? msg.attrs.p : '';
+  const timeAttrs = buildChatTimeAttrs();
 
   if (g && client.logged) {
     const safeText = escapeXml(text);
-    const xml = `<${CMD.send} u="${escapeXml(client.username)}" t="${type}" p="${pen}" g="${g}">${safeText}</${CMD.send}>`;
+    const xml = `<${CMD.send} u="${escapeXml(client.username)}" t="${type}" p="${pen}" g="${g}" h="${timeAttrs.h}" d="${timeAttrs.d}">${safeText}</${CMD.send}>`;
     broadcastToChannel(g, xml);
 } else if (msg.attrs.u) {
   const targetUser = msg.attrs.u;
@@ -971,7 +1167,7 @@ case 'send': {
   // Echo au sender, indispensable pour afficher sa propre ligne
   sendToClient(
     socket,
-    `<${CMD.send} u="${escapeXml(client.username)}" t="${type}" p="${pen}">${safeText}</${CMD.send}>`
+    `<${CMD.send} u="${escapeXml(client.username)}" t="${type}" p="${pen}" h="${timeAttrs.h}" d="${timeAttrs.d}">${safeText}</${CMD.send}>`
   );
 
   // Envoi au destinataire
@@ -979,7 +1175,7 @@ case 'send': {
     if (cl.username === targetUser) {
       sendToClient(
         sock,
-        `<${CMD.send} u="${escapeXml(client.username)}" t="${type}" p="${pen}">${safeText}</${CMD.send}>`
+        `<${CMD.send} u="${escapeXml(client.username)}" t="${type}" p="${pen}" h="${timeAttrs.h}" d="${timeAttrs.d}">${safeText}</${CMD.send}>`
       );
     }
   }
@@ -1058,17 +1254,42 @@ case 'fbouille': {
 
 case 'createchannel': {
   const otherUser = msg.attrs.u || '';
+  const requester = client.username || '';
   const title = msg.content || otherUser || 'Discussion privée';
 
-  if (!otherUser) {
+  if (!otherUser || !requester) {
     sendToClient(socket, `<${CMD.error} />`);
     break;
+  }
+
+  const sortedUsers = [requester.toLowerCase(), otherUser.toLowerCase()].sort();
+  const privateGroup = `pm_${sortedUsers[0]}_${sortedUsers[1]}`;
+  const privatePass = `pw_${sortedUsers[0].slice(0, 4)}_${sortedUsers[1].slice(0, 4)}`;
+
+  if (!channels[privateGroup]) {
+    channels[privateGroup] = {
+      desc: `Discussion privée ${requester}/${otherUser}`,
+      topic: title,
+      users: new Set([requester, otherUser]),
+      participants: [requester, otherUser],
+      private: true,
+      pass: privatePass,
+    };
+  } else {
+    channels[privateGroup].users.add(requester);
+    channels[privateGroup].users.add(otherUser);
   }
 
   // Accusé de réception de l’ouverture de la discussion privée
   sendToClient(
     socket,
-    `<${CMD.createchannel} u="${escapeXml(otherUser)}">${escapeXml(title)}</${CMD.createchannel}>`
+    `<${CMD.createchannel} u="${escapeXml(otherUser)}" g="${privateGroup}" p="${privatePass}">${escapeXml(title)}</${CMD.createchannel}>`
+  );
+
+  // Invite "privée" envoyée au demandeur pour ouvrir immédiatement la box
+  sendToClient(
+    socket,
+    `<${CMD.invitechat} u="${escapeXml(otherUser)}" g="${privateGroup}" p="${privatePass}" />`
   );
 
   // On pousse aussi les infos connues sur l’autre user
@@ -1091,8 +1312,40 @@ case 'createchannel': {
     `<${CMD.trace} u="${escapeXml(otherUser)}" p="1" s="00000" mu="0000-00-00 00:00:00" f="${bouilleOf(ud)}" />`
   );
 
+  // Si l'autre utilisateur est connecté, il reçoit aussi l'invitation.
+  for (const targetSock of getSocketsForUsername(otherUser)) {
+    sendToClient(
+      targetSock,
+      `<${CMD.invitechat} u="${escapeXml(requester)}" g="${privateGroup}" p="${privatePass}" />`
+    );
+  }
+
   break;
 }
+
+    // ── invitechat: invite a user to an existing private channel ──
+    case 'invitechat': {
+      const g = msg.attrs.g || '';
+      const targetUser = msg.attrs.u || '';
+      const requester = client.username || '';
+      const channel = channels[g];
+
+      if (!g || !targetUser || !requester || !channel) {
+        break;
+      }
+
+      const pass = msg.attrs.p || channel.pass || '';
+      channel.users.add(requester);
+      channel.users.add(targetUser);
+
+      for (const targetSock of getSocketsForUsername(targetUser)) {
+        sendToClient(
+          targetSock,
+          `<${CMD.invitechat} u="${escapeXml(requester)}" g="${g}" p="${pass}" />`
+        );
+      }
+      break;
+    }
 
     // ── xpflag ──
     case 'xpflag': {


### PR DESCRIPTION
### Motivation
- Make local development possible without committing binary SWFs by providing in-place patch scripts that rewrite hardcoded beta hosts to the local shim. 
- Fix legacy URL concatenation and host/path edge-cases so Ruffle and Frusion loaders fetch assets reliably from the local shim. 
- Improve the backend’s legacy emulation (avatar/fbouille, inventory, discs, chat, and preference data) to match expected SWF behaviors and corner cases.

### Description
- Add `patch-frusion-swfs.js` to perform in-place, length-preserving string patches on target Frusion SWFs and back them up, and update `package.json` to run the patchers before `server.js` on `npm start`.
- Extend `patch-swf.js` to use safer slash-padding (`/./` style) for short host replacements, normalize several previously-patched constants, and add extra byte/string patches and log messaging changes.
- Enhance `public/ruffle.html` fetch/XHR rewrite logic to normalize missing slashes from legacy concatenations and ensure rewritten paths always include a leading slash; set the player `domain` to a slash-stable value and `base` to an absolute shim URL.
- Small ActionScript fix in `frutiparc/FPFileMng.as` to defensively set `inf.pos` when `extra` may be undefined.
- Large server-side compatibility improvements in `server.js`: add default pen item IDs and helper `withDefaultPens`, relax bouille normalization to base62 tokens, add new default preferences, provide a famille1 fallback when the repo contains a tiny stub, implement richer `/ff/ls` responses (inventory, disccollector, root/desktop), add a `/do/ld` disc->game mapping with SWF lists, include `k=0` in `/do/eb` response, ensure `onident`/`do/onident` expose default pen items, add compatibility aliases for patched Frusion movie names and static routes for game assets, and serve SWFs under `/swf/*` as before.
- Substantially improve chat/CBee handling: add socket/user lookup helpers, consistent time attributes on chat messages (`h` and `d`), private PM channel creation and invitation handling (`createchannel`, `invitechat`), `userlist` command support, and safer name resolution for participants.

### Testing
- Ran the SWF patchers in check mode via `node patch-swf.js --check` and `node patch-frusion-swfs.js --check`, and both completed without error indicating patchable occurrences or no-op state.
- No automated unit tests were added; changes were exercised with the patcher scripts' checks (above).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ced28c7a8883208d034bd5ca5b6793)