### PR TITLE
Add alternate login page and persistent NPC users in chat

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -23,6 +23,7 @@
     <div class="actions">
       <a href="/legacy">Entrer dans Frutiparc</a>
       <a class="secondary" href="/login">Connexion / Inscription</a>
+      <a class="secondary" href="/login-bis.html">Accueil bis</a>
     </div>
   </div>
 </body>

--- a/public/login-bis.html
+++ b/public/login-bis.html
@@ -1,0 +1,401 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Frutiparc — Accueil bis</title>
+  <style>
+    :root {
+      --green-bg: #b7e17e;
+      --green-dark: #6a931b;
+      --green-mid: #84b935;
+      --text: #2e3a1d;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: Verdana, Arial, sans-serif;
+      color: var(--text);
+      background: var(--green-bg) url('/images/bg.gif') center/120% no-repeat;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 20px 16px 64px;
+    }
+
+    .topbar {
+      position: relative;
+      width: min(1056px, 100%);
+      height: 30px;
+      margin-top: 48px;
+      background: #fff;
+      border-radius: 10px;
+      box-shadow: 0 4px 10px rgba(0,0,0,.18);
+      padding: 4px 30px 4px 132px;
+      display: flex;
+      align-items: center;
+    }
+    .logo {
+      position: absolute;
+      left: -80px;
+      top: -56px;
+      height: 90px;
+      width: auto;
+    }
+
+    .login-form {
+      width: 100%;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 12px;
+    }
+    .login-form input {
+      height: 22px;
+      border: 1px solid #b8c9a0;
+      border-radius: 4px;
+      padding: 2px 6px;
+      min-width: 110px;
+      font-size: 12px;
+    }
+    .btn {
+      border: 0;
+      border-radius: 5px;
+      padding: 4px 10px;
+      font-weight: bold;
+      cursor: pointer;
+      font-size: 12px;
+    }
+    .btn-primary { background: #8fc93b; color: #264008; }
+    .btn-secondary { background: #daeac2; color: #3e5720; }
+
+    .layout {
+      width: min(880px, 100%);
+      display: grid;
+      grid-template-columns: 176px minmax(0, 1fr);
+      gap: 24px;
+      margin-top: 20px;
+      flex: 1;
+    }
+
+    .games {
+      height: 405px;
+      background: #fff;
+      border-radius: 10px;
+      padding: 8px;
+      box-shadow: 0 4px 10px rgba(0,0,0,.15);
+      overflow: hidden;
+    }
+    .games h3 {
+      text-align: center;
+      color: #777;
+      margin: 0 0 6px;
+      font-size: 14px;
+    }
+    .games-list {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+    .game-card {
+      width: 160px;
+      height: 32px;
+      border: 2px solid #a5a5a5;
+      border-radius: 8px;
+      overflow: hidden;
+      cursor: pointer;
+      transition: height .35s ease;
+      background: #d8d8d8;
+    }
+    .game-card img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      opacity: .6;
+      transition: opacity .25s ease;
+      display: block;
+    }
+    .game-card.active {
+      height: 160px;
+    }
+    .game-card.active img { opacity: 1; }
+    .game-card.compact { height: 18px; }
+
+    .main {
+      height: 380px;
+      background: #fff;
+      border-radius: 10px;
+      box-shadow: 0 4px 10px rgba(0,0,0,.15);
+      padding: 16px;
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 220px;
+      gap: 20px;
+    }
+    .main h1 { margin: 0 0 8px; font-size: 24px; }
+    .main p { margin: 6px 0; font-size: 13px; line-height: 1.35; }
+    .cta { margin-top: 16px; display: flex; gap: 12px; }
+    .cta img { height: 40px; cursor: pointer; }
+    .welcome { height: 285px; max-width: 100%; object-fit: contain; }
+
+    .status {
+      width: min(880px, 100%);
+      margin-top: 8px;
+      min-height: 20px;
+      text-align: center;
+      font-size: 12px;
+      color: #334a14;
+      font-weight: 700;
+    }
+
+    .loading {
+      width: min(880px, 100%);
+      margin-top: 60px;
+      background: #fff;
+      border-radius: 10px;
+      padding: 28px;
+      text-align: center;
+      box-shadow: 0 4px 10px rgba(0,0,0,.16);
+    }
+    .loading .bar { height: 12px; border-radius: 20px; background: #e7efda; overflow: hidden; margin-top: 10px; }
+    .loading .bar::before {
+      content: '';
+      display: block;
+      height: 100%;
+      width: 45%;
+      border-radius: 20px;
+      background: linear-gradient(90deg, #8dc83d, #b6e075);
+      animation: pulse 1s linear infinite alternate;
+    }
+    @keyframes pulse { from { transform: translateX(-25%);} to { transform: translateX(90%);} }
+
+    footer {
+      position: fixed;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      text-align: center;
+      font-size: 11px;
+    }
+    .footer-top { background: #fff; color: #222; padding: 4px; }
+    .footer-bottom { background: var(--green-dark); color: #fff; padding: 4px; }
+
+    .hidden { display: none !important; }
+  </style>
+</head>
+<body>
+  <header class="topbar" id="topbar">
+    <img class="logo" src="/images/logo.gif" alt="Frutiparc" />
+    <form id="login-form" class="login-form" autocomplete="on">
+      <label for="username">Pseudo</label>
+      <input id="username" name="username" minlength="3" maxlength="20" required />
+      <label for="password">Code secret</label>
+      <input id="password" name="password" type="password" minlength="6" maxlength="80" required />
+      <button class="btn btn-primary" type="submit">Connexion</button>
+      <button class="btn btn-secondary" type="button" id="register-toggle">Créer un compte</button>
+    </form>
+  </header>
+
+  <form id="register-form" class="topbar hidden" autocomplete="on">
+    <div class="login-form">
+      <strong>Inscription</strong>
+      <label for="reg-username">Pseudo</label>
+      <input id="reg-username" name="username" minlength="3" maxlength="20" required />
+      <label for="reg-password">Code secret</label>
+      <input id="reg-password" name="password" type="password" minlength="6" maxlength="80" required />
+      <button class="btn btn-primary" type="submit">Valider</button>
+      <button class="btn btn-secondary" type="button" id="register-cancel">Annuler</button>
+    </div>
+  </form>
+
+  <section id="loading" class="loading hidden">
+    <h2>Connexion en cours…</h2>
+    <p>Préparation de ton bureau Frutiz.</p>
+    <div class="bar"></div>
+  </section>
+
+  <section id="main-content" class="layout">
+    <aside class="games">
+      <h3 id="game-title">Sélectionner un jeu</h3>
+      <div class="games-list" id="games-list"></div>
+    </aside>
+
+    <article class="main">
+      <div>
+        <img src="/images/welcome_title.gif" alt="Bienvenue sur Frutiparc" />
+        <p><strong>Découvrez l'univers fruité de Frutiparc ! <span style="color:#d82222;">Inscrivez-vous</span></strong> et jouez à nos jeux fruités : réflexion, arcade et multijoueurs.</p>
+        <p>Chaque jour, profitez de plusieurs parties gratuites pour battre les autres joueurs et grimper au classement.</p>
+        <p>Frutiparc c'est aussi le mode Frutiz : e-mail, salons de discussions, forums et blog, dans une interface fruitée.</p>
+
+        <div class="cta">
+          <img src="/images/decouvrir.gif" alt="Découvrir" />
+          <img src="/images/sinscrire.gif" alt="S'inscrire" id="cta-register" />
+        </div>
+      </div>
+      <div>
+        <img src="/images/welcome.gif" alt="Frutiparc" class="welcome" />
+      </div>
+    </article>
+  </section>
+
+  <section id="welcome-user" class="loading hidden">
+    <h2>Bienvenue sur le bureau Frutiz</h2>
+    <p id="welcome-user-text"></p>
+    <p><a href="/legacy">Entrer dans Frutiparc</a></p>
+  </section>
+
+  <div class="status" id="status" aria-live="polite"></div>
+
+  <footer>
+    <div class="footer-top">Aide (Gaspard) · Oubli de code secret</div>
+    <div class="footer-bottom">© 2002-2007 Motion-Twin · Tous droits réservés · Frutiparc est une marque déposée de Motion Twin<br/>Partenaires : KadoKado · Dinoparc · Monlapin.net · Jeux Gratuits</div>
+  </footer>
+
+  <script>
+    const games = [
+      { id: 'bk', name: 'Burning Kiwi', image: 'bk.png' },
+      { id: 'frutisnake', name: 'FrutiSnake 2', image: 'frutisnake.png' },
+      { id: 'mb', name: 'Motion Ball 2', image: 'mb.png' },
+      { id: 'fb', name: 'FrutiBandas', image: 'fb.png' },
+      { id: 'swapou', name: 'Swapou 2', image: 'swapou.png' },
+      { id: 'grapiz', name: 'Grapiz', image: 'grapiz.png' },
+      { id: 'kaluga', name: 'Kaluga', image: 'kaluga.png' },
+      { id: 'mwave', name: 'Mini-Wave', image: 'mwave.png' },
+      { id: 'jamajama', name: 'JamaJama', image: 'jamajama.png' },
+      { id: 'mpixiz', name: 'Mini-Pixiz', image: 'mpixiz.png' }
+    ];
+
+    const loginForm = document.getElementById('login-form');
+    const registerForm = document.getElementById('register-form');
+    const topbar = document.getElementById('topbar');
+    const loadingEl = document.getElementById('loading');
+    const mainContent = document.getElementById('main-content');
+    const welcomeUser = document.getElementById('welcome-user');
+    const welcomeUserText = document.getElementById('welcome-user-text');
+    const statusEl = document.getElementById('status');
+    const gameTitle = document.getElementById('game-title');
+    const gamesList = document.getElementById('games-list');
+
+    let selectedGame = null;
+
+    function setStatus(text, error = false) {
+      statusEl.textContent = text || '';
+      statusEl.style.color = error ? '#b31111' : '#334a14';
+    }
+
+    async function postJson(url, body) {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data.message || `Erreur HTTP ${res.status}`);
+      }
+      return data;
+    }
+
+    function setLoading(visible) {
+      loadingEl.classList.toggle('hidden', !visible);
+      topbar.classList.toggle('hidden', visible);
+      registerForm.classList.add('hidden');
+      mainContent.classList.toggle('hidden', visible);
+      setStatus(visible ? 'Connexion en cours…' : '');
+    }
+
+    function renderGames() {
+      gamesList.innerHTML = '';
+      games.forEach((game) => {
+        const card = document.createElement('div');
+        card.className = 'game-card';
+        if (selectedGame === game.name) card.classList.add('active');
+        if (selectedGame && selectedGame !== game.name) card.classList.add('compact');
+
+        const img = document.createElement('img');
+        img.src = `/images/${game.image}`;
+        img.alt = game.name;
+        img.onerror = () => {
+          img.style.objectFit = 'contain';
+          img.style.background = '#c7d7ad';
+          img.style.padding = '3px';
+        };
+
+        card.appendChild(img);
+        card.addEventListener('mouseenter', () => {
+          selectedGame = game.name;
+          gameTitle.textContent = selectedGame;
+          renderGames();
+        });
+        card.addEventListener('mouseleave', () => {
+          selectedGame = null;
+          gameTitle.textContent = 'Sélectionner un jeu';
+          renderGames();
+        });
+        gamesList.appendChild(card);
+      });
+    }
+
+    document.getElementById('register-toggle').addEventListener('click', () => {
+      topbar.classList.add('hidden');
+      registerForm.classList.remove('hidden');
+      setStatus('');
+    });
+
+    document.getElementById('register-cancel').addEventListener('click', () => {
+      registerForm.classList.add('hidden');
+      topbar.classList.remove('hidden');
+      setStatus('');
+    });
+
+    document.getElementById('cta-register').addEventListener('click', () => {
+      topbar.classList.add('hidden');
+      registerForm.classList.remove('hidden');
+      setStatus('Inscris-toi pour rejoindre Frutiparc !');
+    });
+
+    registerForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const body = Object.fromEntries(new FormData(registerForm).entries());
+      setStatus('Création du compte…');
+      try {
+        await postJson('/api/auth/register', body);
+        setStatus('Compte créé. Tu peux te connecter.', false);
+        registerForm.classList.add('hidden');
+        topbar.classList.remove('hidden');
+      } catch (error) {
+        setStatus(error.message || 'Inscription impossible.', true);
+      }
+    });
+
+    loginForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const body = Object.fromEntries(new FormData(loginForm).entries());
+      setLoading(true);
+      try {
+        const data = await postJson('/api/auth/login', body);
+        const minimumDuration = 2000;
+        setTimeout(() => {
+          localStorage.setItem('currentUser', JSON.stringify({ username: body.username }));
+          setLoading(false);
+          mainContent.classList.add('hidden');
+          welcomeUser.classList.remove('hidden');
+          welcomeUserText.textContent = `Connecté en tant que ${body.username}.`;
+          setStatus('Connexion réussie.');
+          setTimeout(() => {
+            window.location.href = data.redirect || '/legacy';
+          }, 800);
+        }, minimumDuration);
+      } catch (error) {
+        const minimumDuration = 2000;
+        setTimeout(() => {
+          setLoading(false);
+          setStatus(error.message || 'Les identifiants sont incorrects.', true);
+        }, minimumDuration);
+      }
+    });
+
+    renderGames();
+  </script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1809,8 +1809,18 @@ const channels = {
   bienvenue: { topic: 'Bienvenue sur Frutiparc !', users: new Set() },
 };
 
-// ── Virtual test user: DebugBot (always connected on pomme) ──
-users['DebugBot'] = {
+// ── Virtual users / PNJ (always connected on pomme) ──
+const CONNECTED_NPCS = new Set([
+  'DebugBot',
+  'Renault',
+  'tigrenoir',
+  'SakurAmalia',
+  'EmiLicorne',
+  'kasparov',
+  'Gaspard',
+]);
+
+users.DebugBot = {
   pass: '',
   xp: 1000000,
   kikooz: 100,
@@ -1825,8 +1835,167 @@ users['DebugBot'] = {
   prefs: '',
   isModerator: false,
   needsBouille: false,
+  city: 'Frutiparc',
+  realJob: 'Bot de debug',
+  firstName: 'Debug',
+  lastName: 'Bot',
+  comment: 'Bot de test connecté en permanence.',
 };
-channels.pomme.users.add('DebugBot');
+
+users.Renault = {
+  pass: '',
+  xp: 424242,
+  kikooz: 100,
+  fbouille: '00000d0r020f0l0000000000',
+  items: withDefaultPens([1, 2, 3]),
+  contacts: [],
+  blacklist: [],
+  gender: 'M',
+  birthday: '1991-01-01',
+  country: '1',
+  region: '0',
+  countryIndex: '1',
+  regionIndex: '0',
+  prefs: '',
+  isModerator: true,
+  needsBouille: false,
+  city: 'Namur',
+  realJob: 'Blagueur',
+  firstName: 'C-A',
+  lastName: 'Run',
+  comment: 'Frutimarié à tigrenoir, frutipapa de SakurAmalia et EmiLicorne',
+  siteUrl: 'http://renault.up.md/FrutiStats/',
+};
+
+users.tigrenoir = {
+  pass: '',
+  xp: 33,
+  kikooz: 100,
+  fbouille: '0004060N02000O030y0t0j00',
+  items: withDefaultPens([1, 2, 3]),
+  contacts: [],
+  blacklist: [],
+  gender: 'F',
+  birthday: '1992-01-01',
+  country: '1',
+  region: '0',
+  countryIndex: '1',
+  regionIndex: '0',
+  prefs: '',
+  isModerator: false,
+  needsBouille: false,
+  city: 'Namur',
+  realJob: 'Fleuriste',
+  firstName: 'J',
+  lastName: 'Run',
+  comment: 'Frutimariée à Renault, frutimaman de SakurAmalia et EmiLicorne',
+  siteUrl: '',
+};
+
+users.SakurAmalia = {
+  pass: '',
+  xp: 5,
+  kikooz: 100,
+  fbouille: '0004040J020k0P00000t0j00',
+  items: withDefaultPens([1, 2, 3]),
+  contacts: [],
+  blacklist: [],
+  gender: 'F',
+  birthday: '2019-01-01',
+  country: '1',
+  region: '0',
+  countryIndex: '1',
+  regionIndex: '0',
+  prefs: '',
+  isModerator: false,
+  needsBouille: false,
+  city: 'Namur',
+  realJob: 'Dresseuse Pokémon',
+  firstName: 'A',
+  lastName: 'Run',
+  comment: 'Frutifille de tigrenoir et Renault, frutisoeur de EmiLicorne',
+  siteUrl: '',
+};
+
+users.EmiLicorne = {
+  pass: '',
+  xp: 2,
+  kikooz: 100,
+  fbouille: '0004070K020n0e0a000O0000',
+  items: withDefaultPens([1, 2, 3]),
+  contacts: [],
+  blacklist: [],
+  gender: 'F',
+  birthday: '2022-01-01',
+  country: '1',
+  region: '0',
+  countryIndex: '1',
+  regionIndex: '0',
+  prefs: '',
+  isModerator: false,
+  needsBouille: false,
+  mutedUntil: '2030-01-01 00:00:00',
+  city: 'Namur',
+  realJob: 'Dresseuse de dragons',
+  firstName: 'É',
+  lastName: 'Run',
+  comment: 'Frutifille de tigrenoir et Renault, frutisoeur de SakurAmalia',
+  siteUrl: '',
+};
+
+users.kasparov = {
+  pass: '',
+  xp: 5353,
+  kikooz: 100,
+  fbouille: '0005000Q010t0a04010t0w00',
+  items: withDefaultPens([1, 2, 3]),
+  contacts: [],
+  blacklist: [],
+  gender: 'M',
+  birthday: '1993-01-01',
+  country: '0',
+  region: '2',
+  countryIndex: '0',
+  regionIndex: '2',
+  prefs: '',
+  isModerator: true,
+  needsBouille: false,
+  city: 'Cachan',
+  realJob: 'Détective',
+  firstName: 'Rémi',
+  lastName: 'Sans famille',
+  comment: '[Frutimarié à Bee le Vendredi 19 Decembre 2008 à 21h42 et 6 secondes.] Вив каспаров [19:38:04] Babylou: Ah oui tu as raison kaspa [Animateur du 29 Aout 2007 au 18 Janvier 2009] [Modérateur depuis le 23 Janvier 2008]',
+  siteUrl: 'http://spikeo.no-ip.org/',
+};
+
+users.Gaspard = {
+  pass: '',
+  xp: 9999999,
+  kikooz: 100,
+  fbouille: '0n0000000000000000000000',
+  items: withDefaultPens([1, 2, 3]),
+  contacts: [],
+  blacklist: [],
+  gender: 'M',
+  birthday: '2004-03-24',
+  country: '0',
+  region: '0',
+  countryIndex: '0',
+  regionIndex: '0',
+  prefs: '',
+  isModerator: false,
+  needsBouille: false,
+  city: '',
+  realJob: '',
+  firstName: 'Gaspard',
+  lastName: '',
+  comment: '',
+  siteUrl: '',
+};
+
+for (const npc of CONNECTED_NPCS) {
+  channels.pomme.users.add(npc);
+}
 
 const xmlSocketClients = new Map(); // socket -> { sid, username, logged, channels: Set }
 
@@ -1888,13 +2057,13 @@ function kickUserFromChannel(channelName, targetUser, byUser, reason = 'kick') {
     }
   }
 
-  // Respawn DebugBot after 5 seconds if it was kicked
-  if (targetUser === 'DebugBot') {
+  // Respawn connected PNJ after 5 seconds if one is kicked
+  if (CONNECTED_NPCS.has(targetUser)) {
     setTimeout(() => {
       if (channels[channelName]) {
-        channels[channelName].users.add('DebugBot');
-        // Broadcast userjoined so other clients see DebugBot reappear
-        broadcastToChannel(channelName, `<${CMD.userjoined} u="DebugBot" g="${escapeXml(channelName)}" />`);
+        channels[channelName].users.add(targetUser);
+        // Broadcast userjoined so other clients see PNJ reappear
+        broadcastToChannel(channelName, `<${CMD.userjoined} u="${escapeXml(targetUser)}" g="${escapeXml(channelName)}" />`);
       }
     }, 5000);
   }


### PR DESCRIPTION
### Motivation
- Provide a modernized/alternate landing and login experience alongside the legacy entry page. 
- Offer a richer chat presence by adding several always-connected NPC/virtual users to recreate an active room. 
- Generalize the respawn logic so any connected NPC reappears automatically after being kicked.

### Description
- Added a new static page `public/login-bis.html` which implements an alternate homepage with login/registration forms, a games selector UI, client-side `postJson` calls to `'/api/auth/login'` and `'/api/auth/register'`, and interactive JS for game previews. 
- Updated `public/index.html` to include a link to the new `Accueil bis` page. 
- In `server.js` introduced a `CONNECTED_NPCS` set and populated multiple virtual users in the global `users` object (including `DebugBot`, `Renault`, `tigrenoir`, `SakurAmalia`, `EmiLicorne`, `kasparov`, `Gaspard`) with initial profile fields and items. 
- Ensured those NPCs are added to the `channels.pomme.users` set on startup and generalized the respawn behavior in `kickUserFromChannel` so any member of `CONNECTED_NPCS` is re-added to the channel and a `userjoined` event is broadcast after a delay.

### Testing
- No automated tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da9f9097c883209ff2d2662d40ca52)