### PR TITLE
Normalize game identifiers and improve SWF/FrutiScore score saving and auto-ident

### DIFF
--- a/public/game-popup.html
+++ b/public/game-popup.html
@@ -50,6 +50,14 @@
     var u = String(url || "");
     if (/(?:^|\/)s\d+$/.test(u)) {
       var full = u.startsWith("/") ? u : new URL(u, document.baseURI).href;
+      try {
+        var sid = new URLSearchParams(window.location.search).get("sid") || "";
+        if (sid) {
+          var saveUrl = new URL(full, window.location.origin);
+          if (!saveUrl.searchParams.get("sid")) saveUrl.searchParams.set("sid", sid);
+          full = saveUrl.toString();
+        }
+      } catch (e) {}
       fetch(full).catch(function() {});
       return null;
     }

--- a/server.js
+++ b/server.js
@@ -220,16 +220,68 @@ const RANKINGS = {
 
 // Map a game/disc identifier to a ranking id.
 function rankingIdForGame(gameName) {
-  const key = String(gameName || '').toLowerCase();
+  const raw = String(gameName || '').trim();
+  const key = raw.toLowerCase();
   if (!key) return null;
   const direct = `${key}_classic`;
   if (RANKINGS[direct]) return direct;
-  // Accept disc uids too (kaluga1, snake3, swapou1, miniwave1).
-  const disc = GAME_DISCS && GAME_DISCS[key];
-  if (disc && disc.swfName) {
-    const via = `${disc.swfName}_classic`;
+  // Accept Frutiparc disc uids directly (kaluga1, snake3, swapou1, miniwave1).
+  const directDisc = GAME_DISCS && GAME_DISCS[key];
+  if (directDisc && directDisc.swfName) {
+    const via = `${String(directDisc.swfName).toLowerCase()}_classic`;
     if (RANKINGS[via]) return via;
   }
+
+  // Accept game path forms returned by /do/ld and used by Frusion:
+  //   games/snake3/snake3.swf
+  //   /games/snake3/snake3.swf
+  //   /swf/games/snake3/snake3.swf
+  const normalizedCandidates = new Set([
+    key,
+    key.replace(/^\/+/, ''),
+    key.replace(/^\/?swf\//, ''),
+  ]);
+
+  for (const [discUid, disc] of Object.entries(GAME_DISCS || {})) {
+    const swfName = String((disc && disc.swfName) || '').toLowerCase();
+    if (swfName) {
+      const via = `${swfName}_classic`;
+      if (RANKINGS[via] && (normalizedCandidates.has(swfName) || normalizedCandidates.has(String(discUid).toLowerCase()))) {
+        return via;
+      }
+    }
+
+    const gameId = String((disc && disc.gameId) || '').toLowerCase();
+    const filePaths = [];
+    if (gameId) filePaths.push(gameId);
+    if (Array.isArray(disc && disc.files)) {
+      for (const f of disc.files) {
+        if (f && f.u) filePaths.push(String(f.u).toLowerCase());
+      }
+    }
+
+    if (swfName && RANKINGS[`${swfName}_classic`]) {
+      for (const p of filePaths) {
+        const pathVariants = [
+          p,
+          `/${p}`,
+          `swf/${p}`,
+          `/swf/${p}`,
+        ];
+        if (pathVariants.some((v) => normalizedCandidates.has(v))) {
+          return `${swfName}_classic`;
+        }
+      }
+    }
+  }
+
+  // Fallback: infer ranking id from SWF filename in a path-like input.
+  // Example: games/snake3/snake3.swf -> snake3_classic
+  const lastSeg = normalizedCandidates.values().next().value.split('/').pop() || '';
+  const base = lastSeg.replace(/\.swf$/i, '');
+  const fromBase = `${base}_classic`;
+  if (RANKINGS[fromBase]) return fromBase;
+
   return null;
 }
 
@@ -662,14 +714,18 @@ app.get(/^\/(?:swf\/)?games\/([^/]+)\/s(\d+)$/, (req, res) => {
   const gameName = req.params[0];
   const scoreVal = parseInt(req.params[1]) || 0;
   let username = '';
+  const sid = getSidFromRequest(req, req.query || {});
+  if (sid && sessions[sid]) username = sessions[sid].user || '';
   const ip = getClientIp(req);
   const fallbackSid = ip ? recentSidByIp.get(ip) : undefined;
-  if (fallbackSid && sessions[fallbackSid]) username = sessions[fallbackSid].user || '';
+  if (!username && fallbackSid && sessions[fallbackSid]) username = sessions[fallbackSid].user || '';
   if (!username || !scoreVal) {
+    console.log(`[SWF-SCORE] skip save user="${username}" sid="${sid}" ip="${ip}" game="${gameName}" score=${scoreVal}`);
     return res.type('text/plain').send('ok=0');
   }
   const rankingId = rankingIdForGame(gameName);
   if (!rankingId) {
+    console.log(`[SWF-SCORE] unknown ranking game="${gameName}" sid="${sid}" user="${username}"`);
     return res.type('text/plain').send('ok=0');
   }
   const result = persistScore(username, rankingId, scoreVal, '');
@@ -1915,17 +1971,48 @@ wssChat.on('connection', (ws) => {
 // second TCP connection.  Ruffle can't reliably open two WebSocket
 // connections to the same origin/path, so we use /score as a
 // dedicated endpoint.
-wssScore.on('connection', (ws) => {
+wssScore.on('connection', (ws, request) => {
   console.log('[FSCORE-WS] New FrutiScore WebSocket client');
 
   let loggedUser = '';
+  let currentGame = '';
   let buffer = '';
+  let autoIdentTimer = null;
+  const reqUrl = request && request.url ? String(request.url) : '';
+  let hintedSid = '';
+  try {
+    const u = new URL(reqUrl, 'http://localhost');
+    hintedSid = u.searchParams.get('sid') || u.searchParams.get('c') || '';
+  } catch {}
+  const hintedIp = request
+    ? String((request.headers && request.headers['x-forwarded-for']) || '')
+      .split(',')[0]
+      .trim()
+    : '';
 
   function wsSend(xmlStr) {
     try {
       ws.send(xmlStr + '\0');
       console.log('[FSCORE-WS] →', xmlStr.substring(0, 200));
     } catch (e) { /* ignore */ }
+  }
+
+  function tryAutoIdent(reason = '') {
+    if (loggedUser) return;
+    let hintedUser = '';
+    if (hintedSid && sessions[hintedSid] && sessions[hintedSid].user) {
+      hintedUser = sessions[hintedSid].user;
+    }
+    if (!hintedUser && hintedIp && recentSidByIp.has(hintedIp)) {
+      const sid = recentSidByIp.get(hintedIp);
+      if (sid && sessions[sid] && sessions[sid].user) {
+        hintedUser = sessions[sid].user;
+      }
+    }
+    loggedUser = hintedUser || 'anonymous';
+    const user = users[loggedUser] || {};
+    wsSend(`<${CMD.ident} l="${escapeXml(loggedUser)}" x="${user.xp || 0}" f="${bouilleOf(user)}" />`);
+    console.log(`[FSCORE-WS] Auto-ident(${reason}) user="${loggedUser}" sidHint="${hintedSid}" ipHint="${hintedIp}"`);
   }
 
   ws.on('message', (rawMsg) => {
@@ -1950,17 +2037,26 @@ wssScore.on('connection', (ws) => {
 
       switch (cmdName) {
         case 'time': {
-          const now = new Date();
-          const pad = (n) => String(n).padStart(2, '0');
-          const ts = `${now.getFullYear()}.${pad(now.getMonth()+1)}.${pad(now.getDate())}.${pad(now.getHours())}.${pad(now.getMinutes())}.${pad(now.getSeconds())}`;
+          // Keep the exact same timestamp format as the TCP CBee handler
+          // so legacy parsers (ServTime.setFromString) behave identically.
+          const ts = formatDateTime(new Date());
           wsSend(`<${CMD.time}>${ts}</${CMD.time}>`);
           break;
         }
         case 'ip': {
           wsSend(`<${CMD.ip}>127.0.0.1</${CMD.ip}>`);
+          // Some legacy FrutiScore paths stay stuck after time/ip and never
+          // issue ident(). Send an ident proactively, then retry once shortly
+          // after to avoid race conditions with late listener registration.
+          tryAutoIdent('after-ip');
+          if (autoIdentTimer) clearTimeout(autoIdentTimer);
+          autoIdentTimer = setTimeout(() => {
+            tryAutoIdent('after-ip-delay');
+          }, 120);
           break;
         }
         case 'ping': {
+          tryAutoIdent('on-ping');
           wsSend(`<${CMD.ping} />`);
           break;
         }
@@ -1977,6 +2073,41 @@ wssScore.on('connection', (ws) => {
           const user = users[effectiveLogin] || {};
           wsSend(`<${CMD.ident} l="${escapeXml(effectiveLogin)}" x="${user.xp || 0}" f="${bouilleOf(user)}" />`);
           console.log(`[FSCORE-WS] User "${effectiveLogin}" logged in (sid=${sid})`);
+          break;
+        }
+        // startGame (wire "o")
+        case 'join': {
+          if (msg.attrs.d !== undefined) {
+            currentGame = String(msg.attrs.d || '');
+            wsSend(`<${CMD.join} d="${escapeXml(currentGame)}" k="0" />`);
+            console.log(`[FSCORE-WS] startGame disc=${currentGame} user=${loggedUser || '-'}`);
+          }
+          break;
+        }
+        // saveScore (wire "q")
+        case 'channellist': {
+          if (msg.attrs.d !== undefined || msg.attrs.s !== undefined) {
+            const discId = String(msg.attrs.d || '');
+            const scoreVal = Number(msg.attrs.s || 0) || 0;
+            const scoreData = String(msg.attrs.da || msg.attrs.d2 || '');
+            let rankingId = rankingIdForGame(discId);
+            if (!rankingId && currentGame) rankingId = rankingIdForGame(currentGame);
+
+            let res = { updated: false, newScore: scoreVal, oldScore: 0, oldPos: 0, newPos: 0 };
+            if (loggedUser && rankingId) {
+              res = persistScore(loggedUser, rankingId, scoreVal, scoreData);
+              console.log(`[FSCORE-WS] saveScore ${loggedUser} ${rankingId}: ${res.oldScore} -> ${res.newScore} (updated=${res.updated}, pos ${res.oldPos}->${res.newPos})`);
+            } else {
+              console.log(`[FSCORE-WS] saveScore skip persist (user="${loggedUser}" rankingId="${rankingId}" discId="${discId}" currentGame="${currentGame}")`);
+            }
+
+            const rkInfo = rankingId ? (RANKINGS[rankingId] || {}) : {};
+            const rnAttr = rkInfo.name ? ` rn="${escapeXml(rkInfo.name)}"` : '';
+            const rAttr = scoreData ? ` r="${escapeXml(scoreData)}"` : ' r=""';
+            const subAttrs = `${rnAttr}${rAttr} p="${res.newPos}" os="${res.oldScore}" op="${res.oldPos}" s="${res.newScore}"`;
+            wsSend(`<${CMD.channellist} k="0"><rk${subAttrs}/></${CMD.channellist}>`);
+            break;
+          }
           break;
         }
         // listrankings (wire "l" with dt attr)
@@ -2074,6 +2205,7 @@ wssScore.on('connection', (ws) => {
   });
 
   ws.on('close', () => {
+    if (autoIdentTimer) clearTimeout(autoIdentTimer);
     console.log(`[FSCORE-WS] Closed (user=${loggedUser || 'anonymous'})`);
   });
 


### PR DESCRIPTION
### Motivation
- Accept a wider range of game identifier formats used by patched SWFs and Frusion (path-like inputs and various swf/file name forms) so incoming score saves map to the correct ranking. 
- Ensure session hints (sid) are propagated from the player page into SWF-driven save requests so authenticated score saves are credited to the correct user. 
- Make the FrutiScore WebSocket handler more robust by auto-identifying clients when possible, handling start-game/join and score-save messages, and improving logging.

### Description
- In `public/game-popup.html` intercepting `window.open` now appends the `sid` query parameter (if present) to SWF save URLs before firing the background `fetch`, preventing the score popup and allowing the server to see the session id. 
- In `server.js` `rankingIdForGame` was expanded to normalize input (trim/lowercase), accept direct disc UIDs, and match a variety of path-like forms (with or without leading slashes and `/swf/` prefixes), and to infer ranking from SWF filename when possible. 
- The SWF save route (`/^\/(?:swf\/)?games\/([^/]+)\/s(\d+)$/`) now extracts `sid` from the request and prefers it over the IP-based fallback, skips saves when missing user or score, and emits clearer debug logs. 
- The FrutiScore WebSocket handler (`wssScore`) now receives the `request` object, extracts hinted `sid` and client IP, introduces `tryAutoIdent` to proactively send an `<ident>` when appropriate (after `ip`, `ping`, or with a short delay), preserves the legacy timestamp format via `formatDateTime`, and implements handling for `join` (startGame) and `channellist` (saveScore) messages to persist scores and reply with the expected `rk` payload. 
- Improved logging throughout the score save paths and cleaned up timers on WS close. 

### Testing
- Ran automated integration smoke tests that exercise `/swf/.../s<score>` with and without `sid`, `GET/POST /api/saveScore`, and scripted WebSocket exchanges simulating `time`, `ip`, `ident`, `join`, and `channellist` save flows; all tests passed. 
- Verified that existing score persistence functions (`persistScore`, ranking lookups, and ranking listing) behaved identically under the new normalization logic using automated assertions; no regressions detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e283af9acc8320b70d26c1acbd0c77)