### PR TITLE
FrutiScore: seed demo scores, legacy compatibility, SWF sid propagation, and WS protocol enhancements

### DIFF
--- a/public/game-popup.html
+++ b/public/game-popup.html
@@ -50,6 +50,14 @@
     var u = String(url || "");
     if (/(?:^|\/)s\d+$/.test(u)) {
       var full = u.startsWith("/") ? u : new URL(u, document.baseURI).href;
+      try {
+        var sid = new URLSearchParams(window.location.search).get("sid") || "";
+        if (sid) {
+          var saveUrl = new URL(full, window.location.origin);
+          if (!saveUrl.searchParams.get("sid")) saveUrl.searchParams.set("sid", sid);
+          full = saveUrl.toString();
+        }
+      } catch (e) {}
       fetch(full).catch(function() {});
       return null;
     }

--- a/server.js
+++ b/server.js
@@ -184,6 +184,17 @@ const LOGIN_BIS_PAGE_PATH = path.join(__dirname, 'public', 'login-bis.html');
 const SCORES_DIR = path.join(__dirname, 'data');
 const SCORES_FILE = path.join(SCORES_DIR, 'scores.json');
 let scoresData = { users: {} };
+const SEEDED_DEMO_SCORES = {
+  Renault: {
+    snake3_classic: { score: 24500, data: 'seed', updatedAt: '2026-01-01T00:00:00.000Z' },
+  },
+  DebugBot: {
+    snake3_classic: { score: 19840, data: 'seed', updatedAt: '2026-01-01T00:00:00.000Z' },
+  },
+  kasparov: {
+    snake3_classic: { score: 17620, data: 'seed', updatedAt: '2026-01-01T00:00:00.000Z' },
+  },
+};
 
 function loadScores() {
   try {
@@ -209,6 +220,26 @@ function saveScoresFile() {
   }
 }
 
+function seedDemoScores() {
+  if (!scoresData || typeof scoresData !== 'object') scoresData = { users: {} };
+  if (!scoresData.users || typeof scoresData.users !== 'object') scoresData.users = {};
+  for (const [username, rankings] of Object.entries(SEEDED_DEMO_SCORES)) {
+    if (!scoresData.users[username]) scoresData.users[username] = {};
+    for (const [rkId, row] of Object.entries(rankings || {})) {
+      const current = scoresData.users[username][rkId];
+      const currentScore = current && Number.isFinite(Number(current.score)) ? Number(current.score) : 0;
+      const seedScore = Number(row.score) || 0;
+      if (!current || currentScore < seedScore) {
+        scoresData.users[username][rkId] = {
+          score: seedScore,
+          data: row.data || 'seed',
+          updatedAt: row.updatedAt || new Date().toISOString(),
+        };
+      }
+    }
+  }
+}
+
 // Registered ranking IDs (one per game, mode 0 = classic).
 // name = human-readable, game = disc/game name (for client display).
 const RANKINGS = {
@@ -218,18 +249,97 @@ const RANKINGS = {
   miniwave2_classic:{ name: 'MiniWave - Classique',    game: 'miniwave2',type: 'C' },
 };
 
+// Legacy FrutiScore wire descriptors (numeric rk ids used by original clients).
+const LEGACY_RANKINGS = [
+  { rk: '0', internal: null,               ty: 'millisecond', rn: 'Burning kiwi', gs: '0', g: 'bkiwi', section: 'C' },
+  { rk: '1', internal: 'snake3_classic',   ty: '0',           rn: 'Frutisnake 2', gs: '1', g: 'snake3', section: 'C' },
+  { rk: '2', internal: null,               ty: 'ptmb2',       rn: 'Motion Ball 2',gs: '2', g: 'mb2',    section: 'C' },
+  { rk: '3', internal: 'swapou2_classic',  ty: '0',           rn: 'Swapou 2',     gs: '3', g: 'swapou2',section: 'C' },
+  { rk: '4', internal: 'kaluga_classic',   ty: '0',           rn: 'Kaluga',       gs: '4', g: 'kaluga', section: 'C' },
+  { rk: '5', internal: null,               ty: '0',           rn: 'Frutibandas',  gs: '5', g: 'bandas', section: 'C' },
+  { rk: '6', internal: null,               ty: '0',           rn: 'Grapiz',       gs: '6', g: 'grapiz', section: 'C' },
+  { rk: '7', internal: null,               ty: '0',           rn: 'Frutibandas',  gs: '7', g: 'bandas', section: 'L' },
+  { rk: '8', internal: null,               ty: '0',           rn: 'Grapiz',       gs: '8', g: 'grapiz', section: 'L' },
+];
+const LEGACY_RK_TO_INTERNAL = Object.fromEntries(
+  LEGACY_RANKINGS.filter((r) => r.internal).map((r) => [r.rk, r.internal])
+);
+const INTERNAL_TO_LEGACY_RK = Object.fromEntries(
+  LEGACY_RANKINGS.filter((r) => r.internal).map((r) => [r.internal, r.rk])
+);
+
+function resolveInternalRankingId(rkLike) {
+  const raw = String(rkLike || '').trim();
+  if (!raw) return null;
+  if (RANKINGS[raw]) return raw;
+  if (LEGACY_RK_TO_INTERNAL[raw]) return LEGACY_RK_TO_INTERNAL[raw];
+  return null;
+}
+
 // Map a game/disc identifier to a ranking id.
 function rankingIdForGame(gameName) {
-  const key = String(gameName || '').toLowerCase();
+  const raw = String(gameName || '').trim();
+  const key = raw.toLowerCase();
   if (!key) return null;
   const direct = `${key}_classic`;
   if (RANKINGS[direct]) return direct;
-  // Accept disc uids too (kaluga1, snake3, swapou1, miniwave1).
-  const disc = GAME_DISCS && GAME_DISCS[key];
-  if (disc && disc.swfName) {
-    const via = `${disc.swfName}_classic`;
+  // Accept Frutiparc disc uids directly (kaluga1, snake3, swapou1, miniwave1).
+  const directDisc = GAME_DISCS && GAME_DISCS[key];
+  if (directDisc && directDisc.swfName) {
+    const via = `${String(directDisc.swfName).toLowerCase()}_classic`;
     if (RANKINGS[via]) return via;
   }
+
+  // Accept game path forms returned by /do/ld and used by Frusion:
+  //   games/snake3/snake3.swf
+  //   /games/snake3/snake3.swf
+  //   /swf/games/snake3/snake3.swf
+  const normalizedCandidates = new Set([
+    key,
+    key.replace(/^\/+/, ''),
+    key.replace(/^\/?swf\//, ''),
+  ]);
+
+  for (const [discUid, disc] of Object.entries(GAME_DISCS || {})) {
+    const swfName = String((disc && disc.swfName) || '').toLowerCase();
+    if (swfName) {
+      const via = `${swfName}_classic`;
+      if (RANKINGS[via] && (normalizedCandidates.has(swfName) || normalizedCandidates.has(String(discUid).toLowerCase()))) {
+        return via;
+      }
+    }
+
+    const gameId = String((disc && disc.gameId) || '').toLowerCase();
+    const filePaths = [];
+    if (gameId) filePaths.push(gameId);
+    if (Array.isArray(disc && disc.files)) {
+      for (const f of disc.files) {
+        if (f && f.u) filePaths.push(String(f.u).toLowerCase());
+      }
+    }
+
+    if (swfName && RANKINGS[`${swfName}_classic`]) {
+      for (const p of filePaths) {
+        const pathVariants = [
+          p,
+          `/${p}`,
+          `swf/${p}`,
+          `/swf/${p}`,
+        ];
+        if (pathVariants.some((v) => normalizedCandidates.has(v))) {
+          return `${swfName}_classic`;
+        }
+      }
+    }
+  }
+
+  // Fallback: infer ranking id from SWF filename in a path-like input.
+  // Example: games/snake3/snake3.swf -> snake3_classic
+  const lastSeg = normalizedCandidates.values().next().value.split('/').pop() || '';
+  const base = lastSeg.replace(/\.swf$/i, '');
+  const fromBase = `${base}_classic`;
+  if (RANKINGS[fromBase]) return fromBase;
+
   return null;
 }
 
@@ -277,6 +387,7 @@ function getUserScore(username, rankingId) {
 }
 
 loadScores();
+seedDemoScores();
 
 function createDefaultUser(pass) {
   return {
@@ -662,14 +773,18 @@ app.get(/^\/(?:swf\/)?games\/([^/]+)\/s(\d+)$/, (req, res) => {
   const gameName = req.params[0];
   const scoreVal = parseInt(req.params[1]) || 0;
   let username = '';
+  const sid = getSidFromRequest(req, req.query || {});
+  if (sid && sessions[sid]) username = sessions[sid].user || '';
   const ip = getClientIp(req);
   const fallbackSid = ip ? recentSidByIp.get(ip) : undefined;
-  if (fallbackSid && sessions[fallbackSid]) username = sessions[fallbackSid].user || '';
+  if (!username && fallbackSid && sessions[fallbackSid]) username = sessions[fallbackSid].user || '';
   if (!username || !scoreVal) {
+    console.log(`[SWF-SCORE] skip save user="${username}" sid="${sid}" ip="${ip}" game="${gameName}" score=${scoreVal}`);
     return res.type('text/plain').send('ok=0');
   }
   const rankingId = rankingIdForGame(gameName);
   if (!rankingId) {
+    console.log(`[SWF-SCORE] unknown ranking game="${gameName}" sid="${sid}" user="${username}"`);
     return res.type('text/plain').send('ok=0');
   }
   const result = persistScore(username, rankingId, scoreVal, '');
@@ -1501,6 +1616,7 @@ app.get(['/ff/ls', '/ls'], (req, res) => {
         <f u="disccollector" t="disccollector" />
         <f u="inventory" t="inventory" />
         <f u="mycontact" t="mycontact" />
+        <e u="Gaspard" t="contact" s="10" d="0" a="0">Gaspard@frutiparc.com</e>
         <f u="recyclebin" t="recyclebin" />
       </f>`
     );
@@ -1915,17 +2031,78 @@ wssChat.on('connection', (ws) => {
 // second TCP connection.  Ruffle can't reliably open two WebSocket
 // connections to the same origin/path, so we use /score as a
 // dedicated endpoint.
-wssScore.on('connection', (ws) => {
+wssScore.on('connection', (ws, request) => {
   console.log('[FSCORE-WS] New FrutiScore WebSocket client');
 
   let loggedUser = '';
+  let currentGame = '';
   let buffer = '';
+  let autoIdentTimer = null;
+  let bootstrapHintTimer = null;
+  let scoreFlowSeen = false;
+  const reqUrl = request && request.url ? String(request.url) : '';
+  let hintedSid = '';
+  try {
+    const u = new URL(reqUrl, 'http://localhost');
+    hintedSid = u.searchParams.get('sid') || u.searchParams.get('c') || '';
+  } catch {}
+  const hintedIp = request
+    ? String((request.headers && request.headers['x-forwarded-for']) || '')
+      .split(',')[0]
+      .trim()
+    : '';
 
   function wsSend(xmlStr) {
     try {
       ws.send(xmlStr + '\0');
       console.log('[FSCORE-WS] →', xmlStr.substring(0, 200));
     } catch (e) { /* ignore */ }
+  }
+
+  function tryAutoIdent(reason = '') {
+    if (loggedUser) return;
+    let hintedUser = '';
+    if (hintedSid && sessions[hintedSid] && sessions[hintedSid].user) {
+      hintedUser = sessions[hintedSid].user;
+    }
+    if (!hintedUser && hintedIp && recentSidByIp.has(hintedIp)) {
+      const sid = recentSidByIp.get(hintedIp);
+      if (sid && sessions[sid] && sessions[sid].user) {
+        hintedUser = sessions[sid].user;
+      }
+    }
+    loggedUser = hintedUser || 'anonymous';
+    const user = users[loggedUser] || {};
+    wsSend(`<${CMD.ident} l="${escapeXml(loggedUser)}" x="${user.xp || 0}" f="${bouilleOf(user)}" />`);
+    console.log(`[FSCORE-WS] Auto-ident(${reason}) user="${loggedUser}" sidHint="${hintedSid}" ipHint="${hintedIp}"`);
+  }
+
+  function sendBootstrapScoreHints() {
+    if (!loggedUser || scoreFlowSeen) return;
+    const rkList = LEGACY_RANKINGS.filter((r) => !!r.internal);
+    let listInner = '<s ty="C">';
+    for (const [rkId, rk] of Object.entries(RANKINGS)) {
+      listInner += `<rk rk="${escapeXml(rkId)}" rn="${escapeXml(rk.name)}" g="${escapeXml(rk.game)}" ty="${escapeXml(rk.type)}" />`;
+    }
+    listInner += '</s>';
+
+    let userInner = '';
+    for (const rk of rkList) {
+      const info = getUserScore(loggedUser, rk.internal);
+      userInner += `<rk rk="${escapeXml(rk.rk)}" s="${info.score}" p="${info.pos}" />`;
+    }
+
+    // Legacy clients use short rolling request ids (ex: ap/aq/ar...).
+    // Send a small compatibility window so specific listeners can resolve.
+    const hintReqIds = [
+      'ap', 'aq', 'ar', 'as', 'at', 'au', 'av', 'aw', 'ax', 'ay', 'az',
+      'ba', 'bb', 'bc',
+    ];
+    for (const rid of hintReqIds) {
+      wsSend(`<${CMD.kick} r="${rid}">${listInner}</${CMD.kick}>`);
+      wsSend(`<${CMD.unban} r="${rid}">${userInner}</${CMD.unban}>`);
+    }
+    console.log(`[FSCORE-WS] Bootstrap hints sent for user=${loggedUser}`);
   }
 
   ws.on('message', (rawMsg) => {
@@ -1950,17 +2127,29 @@ wssScore.on('connection', (ws) => {
 
       switch (cmdName) {
         case 'time': {
-          const now = new Date();
-          const pad = (n) => String(n).padStart(2, '0');
-          const ts = `${now.getFullYear()}.${pad(now.getMonth()+1)}.${pad(now.getDate())}.${pad(now.getHours())}.${pad(now.getMinutes())}.${pad(now.getSeconds())}`;
+          // Keep the exact same timestamp format as the TCP CBee handler
+          // so legacy parsers (ServTime.setFromString) behave identically.
+          const ts = formatDateTime(new Date());
           wsSend(`<${CMD.time}>${ts}</${CMD.time}>`);
           break;
         }
         case 'ip': {
           wsSend(`<${CMD.ip}>127.0.0.1</${CMD.ip}>`);
+          // Some legacy FrutiScore paths stay stuck after time/ip and never
+          // issue ident(). However, firing ident immediately can race with
+          // local listener setup on the Flash side. Schedule it shortly after.
+          if (autoIdentTimer) clearTimeout(autoIdentTimer);
+          autoIdentTimer = setTimeout(() => {
+            tryAutoIdent('after-ip-delay');
+          }, 250);
+          if (bootstrapHintTimer) clearTimeout(bootstrapHintTimer);
+          bootstrapHintTimer = setTimeout(() => {
+            sendBootstrapScoreHints();
+          }, 700);
           break;
         }
         case 'ping': {
+          tryAutoIdent('on-ping');
           wsSend(`<${CMD.ping} />`);
           break;
         }
@@ -1979,71 +2168,127 @@ wssScore.on('connection', (ws) => {
           console.log(`[FSCORE-WS] User "${effectiveLogin}" logged in (sid=${sid})`);
           break;
         }
+        // startGame (wire "o")
+        case 'join': {
+          if (msg.attrs.d !== undefined) {
+            currentGame = String(msg.attrs.d || '');
+            wsSend(`<${CMD.join} d="${escapeXml(currentGame)}" k="0" />`);
+            console.log(`[FSCORE-WS] startGame disc=${currentGame} user=${loggedUser || '-'}`);
+          }
+          break;
+        }
+        // saveScore (wire "q")
+        case 'channellist': {
+          if (msg.attrs.d !== undefined || msg.attrs.s !== undefined) {
+            const discId = String(msg.attrs.d || '');
+            const scoreVal = Number(msg.attrs.s || 0) || 0;
+            const scoreData = String(msg.attrs.da || msg.attrs.d2 || '');
+            let rankingId = rankingIdForGame(discId);
+            if (!rankingId && currentGame) rankingId = rankingIdForGame(currentGame);
+
+            let res = { updated: false, newScore: scoreVal, oldScore: 0, oldPos: 0, newPos: 0 };
+            if (loggedUser && rankingId) {
+              res = persistScore(loggedUser, rankingId, scoreVal, scoreData);
+              console.log(`[FSCORE-WS] saveScore ${loggedUser} ${rankingId}: ${res.oldScore} -> ${res.newScore} (updated=${res.updated}, pos ${res.oldPos}->${res.newPos})`);
+            } else {
+              console.log(`[FSCORE-WS] saveScore skip persist (user="${loggedUser}" rankingId="${rankingId}" discId="${discId}" currentGame="${currentGame}")`);
+            }
+
+            const rkInfo = rankingId ? (RANKINGS[rankingId] || {}) : {};
+            const rnAttr = rkInfo.name ? ` rn="${escapeXml(rkInfo.name)}"` : '';
+            const rAttr = scoreData ? ` r="${escapeXml(scoreData)}"` : ' r=""';
+            const subAttrs = `${rnAttr}${rAttr} p="${res.newPos}" os="${res.oldScore}" op="${res.oldPos}" s="${res.newScore}"`;
+            wsSend(`<${CMD.channellist} k="0"><rk${subAttrs}/></${CMD.channellist}>`);
+            break;
+          }
+          break;
+        }
         // listrankings (wire "l" with dt attr)
         case 'kick': {
+          scoreFlowSeen = true;
           if (msg.attrs.dt !== undefined) {
             const reqId = msg.attrs.r || '';
             const rAttr = reqId ? ` r="${escapeXml(String(reqId))}"` : '';
-            let inner = '<s ty="C">';
-            for (const [rkId, rk] of Object.entries(RANKINGS)) {
-              inner += `<rk rk="${escapeXml(rkId)}" rn="${escapeXml(rk.name)}" g="${escapeXml(rk.game)}" ty="${escapeXml(rk.type)}" />`;
+            let inner = '';
+            const bySection = { C: [], L: [] };
+            for (const d of LEGACY_RANKINGS) {
+              const section = d.section === 'L' ? 'L' : 'C';
+              bySection[section].push(d);
             }
-            inner += '</s>';
+            for (const sec of ['C', 'L']) {
+              inner += `<s ty="${sec}">`;
+              for (const d of bySection[sec]) {
+                inner += `<rk rk="${escapeXml(d.rk)}" ty="${escapeXml(d.ty)}" rn="${escapeXml(d.rn)}" sst="1" et="10000" gs="${escapeXml(d.gs)}" g="${escapeXml(d.g)}" />`;
+              }
+              inner += '</s>';
+            }
             wsSend(`<${CMD.kick}${rAttr}>${inner}</${CMD.kick}>`);
-            console.log(`[FSCORE-WS] listRankings: ${Object.keys(RANKINGS).length} rankings sent`);
+            console.log(`[FSCORE-WS] listRankings: ${LEGACY_RANKINGS.length} legacy rankings sent`);
             break;
           }
           // rankingResult via bugged wire "l" (rk attr)
           if (msg.attrs.rk !== undefined) {
-            const rkId = String(msg.attrs.rk);
+            const rkInput = String(msg.attrs.rk);
+            const internalId = resolveInternalRankingId(rkInput);
             const reqId = msg.attrs.r || '';
             const start = Number(msg.attrs.s || 0) || 0;
             const limit = Number(msg.attrs.l || 20) || 20;
             const all = [];
-            for (const [u, rlist] of Object.entries(scoresData.users || {})) {
-              if (rlist && rlist[rkId] && Number.isFinite(Number(rlist[rkId].score))) {
-                all.push({ u, s: Number(rlist[rkId].score) });
+            if (internalId) {
+              for (const [u, rlist] of Object.entries(scoresData.users || {})) {
+                if (rlist && rlist[internalId] && Number.isFinite(Number(rlist[internalId].score))) {
+                  all.push({ u, s: Number(rlist[internalId].score) });
+                }
               }
             }
             all.sort((a, b) => b.s - a.s);
             const slice = all.slice(start, start + limit);
             let inner = '';
-            let pos = start;
-            for (const e of slice) { pos += 1; inner += `<r u="${escapeXml(e.u)}" s="${e.s}" p="${pos}" />`; }
+            for (const e of slice) {
+              const ud = users[e.u] || {};
+              inner += `<score u="${escapeXml(e.u)}" x="${ud.xp || 0}" f="${escapeXml(bouilleOf(ud))}" s="${e.s}" t="${formatDateTime(new Date())}" />`;
+            }
             const rAttr = reqId ? ` r="${escapeXml(String(reqId))}"` : '';
-            wsSend(`<${CMD.ban}${rAttr} rk="${escapeXml(rkId)}" t="${all.length}">${inner}</${CMD.ban}>`);
-            console.log(`[FSCORE-WS] rankingResult (bugged wire) ${rkId}: ${slice.length}/${all.length}`);
+            wsSend(`<${CMD.ban}${rAttr} rk="${escapeXml(rkInput)}">${inner}</${CMD.ban}>`);
+            console.log(`[FSCORE-WS] rankingResult (bugged wire) ${rkInput}/${internalId || '-'}: ${slice.length}/${all.length}`);
             break;
           }
           break;
         }
         // rankingResult (wire "m" with rk attr)
         case 'ban': {
+          scoreFlowSeen = true;
           if (msg.attrs.rk !== undefined) {
-            const rkId = String(msg.attrs.rk);
+            const rkInput = String(msg.attrs.rk);
+            const internalId = resolveInternalRankingId(rkInput);
             const reqId = msg.attrs.r || '';
             const start = Number(msg.attrs.s || 0) || 0;
             const limit = Number(msg.attrs.l || 20) || 20;
             const all = [];
-            for (const [u, rlist] of Object.entries(scoresData.users || {})) {
-              if (rlist && rlist[rkId] && Number.isFinite(Number(rlist[rkId].score))) {
-                all.push({ u, s: Number(rlist[rkId].score) });
+            if (internalId) {
+              for (const [u, rlist] of Object.entries(scoresData.users || {})) {
+                if (rlist && rlist[internalId] && Number.isFinite(Number(rlist[internalId].score))) {
+                  all.push({ u, s: Number(rlist[internalId].score) });
+                }
               }
             }
             all.sort((a, b) => b.s - a.s);
             const slice = all.slice(start, start + limit);
             let inner = '';
-            let pos = start;
-            for (const e of slice) { pos += 1; inner += `<r u="${escapeXml(e.u)}" s="${e.s}" p="${pos}" />`; }
+            for (const e of slice) {
+              const ud = users[e.u] || {};
+              inner += `<score u="${escapeXml(e.u)}" x="${ud.xp || 0}" f="${escapeXml(bouilleOf(ud))}" s="${e.s}" t="${formatDateTime(new Date())}" />`;
+            }
             const rAttr = reqId ? ` r="${escapeXml(String(reqId))}"` : '';
-            wsSend(`<${CMD.ban}${rAttr} rk="${escapeXml(rkId)}" t="${all.length}">${inner}</${CMD.ban}>`);
-            console.log(`[FSCORE-WS] rankingResult ${rkId}: ${slice.length}/${all.length}`);
+            wsSend(`<${CMD.ban}${rAttr} rk="${escapeXml(rkInput)}">${inner}</${CMD.ban}>`);
+            console.log(`[FSCORE-WS] rankingResult ${rkInput}/${internalId || '-'}: ${slice.length}/${all.length}`);
             break;
           }
           break;
         }
         // userresult (wire "n" with rs attr)
         case 'unban': {
+          scoreFlowSeen = true;
           if (msg.attrs.rs !== undefined) {
             const rkList = String(msg.attrs.rs || '').split(',').map((s) => s.trim()).filter(Boolean);
             const reqId = msg.attrs.r || '';
@@ -2053,13 +2298,15 @@ wssScore.on('connection', (ws) => {
               if (uChild) targetUser = uChild.attrs.u;
             }
             let inner = '';
-            for (const rkId of rkList) {
-              if (!RANKINGS[rkId]) continue;
-              const info = getUserScore(targetUser, rkId);
-              inner += `<rk rk="${escapeXml(rkId)}" s="${info.score}" p="${info.pos}" />`;
+            for (const rkAny of rkList) {
+              const internalId = resolveInternalRankingId(rkAny);
+              if (!internalId) continue;
+              const info = getUserScore(targetUser, internalId);
+              const rkOut = INTERNAL_TO_LEGACY_RK[internalId] || rkAny || internalId;
+              inner += `<rk rk="${escapeXml(rkOut)}" p="${info.pos}" s="${info.score}" />`;
             }
             const rAttr = reqId ? ` r="${escapeXml(String(reqId))}"` : '';
-            wsSend(`<${CMD.unban}${rAttr}>${inner}</${CMD.unban}>`);
+            wsSend(`<${CMD.unban}${rAttr} u="${escapeXml(targetUser)}">${inner}</${CMD.unban}>`);
             console.log(`[FSCORE-WS] userResult user=${targetUser} rankings=[${rkList.join(',')}]`);
             break;
           }
@@ -2074,6 +2321,8 @@ wssScore.on('connection', (ws) => {
   });
 
   ws.on('close', () => {
+    if (autoIdentTimer) clearTimeout(autoIdentTimer);
+    if (bootstrapHintTimer) clearTimeout(bootstrapHintTimer);
     console.log(`[FSCORE-WS] Closed (user=${loggedUser || 'anonymous'})`);
   });
 


### PR DESCRIPTION
### Motivation

- Seed demo leaderboard entries for a better out-of-the-box experience by introducing starting scores.  
- Improve compatibility with legacy FrutiScore/Flash clients and path formats so ranking lookups and wire protocol exchanges behave like original servers.  
- Ensure SWF-initiated score saves include a `sid` when available and make the FrutiScore WebSocket handler more robust and auto-identify sessions for smoother client integration.  

### Description

- Add `SEEDED_DEMO_SCORES` and `seedDemoScores()` and call `seedDemoScores()` after `loadScores()` to populate demo entries when appropriate.  
- Propagate `sid` from the page URL into intercepted game save requests in `public/game-popup.html` so `/swf/games/.../s<score>` receives session hints.  
- Enhance `rankingIdForGame()` to accept multiple path and filename forms (including `/games/...`, `/swf/...`, disc file lists and SWF filenames) to resolve ranking ids from various inputs.  
- Introduce legacy ranking descriptors `LEGACY_RANKINGS` and mapping helpers `LEGACY_RK_TO_INTERNAL`, `INTERNAL_TO_LEGACY_RK`, and `resolveInternalRankingId()` to translate between numeric legacy rk ids and internal ranking ids.  
- Improve SWF HTTP save route to prefer `sid`-derived session, add diagnostic logging, and avoid overwriting username when fallback is available.  
- Extend the FrutiScore WebSocket handler (`wssScore`) to accept the HTTP `request`, perform auto-ident using hinted `sid` or IP, schedule bootstrap hint messages, support legacy list/score flows, implement `join` (start game) and `channellist` (save score) handling, format ranking responses in legacy-compatible XML (including xp, bouille and timestamps), and clear timers on close.  
- Replace the handcrafted timestamp in WS `time` responses with the shared `formatDateTime()` formatting for parity with TCP handler.  
- Add a small default contact (`Gaspard`) to the `/ff/ls` root response for inventory discovery.  

### Testing

- Ran the project test suite with `npm test` (unit and integration tests); all automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e283af9acc8320b70d26c1acbd0c77)