### PR TITLE
feat(history): add first-login welcome event to user history

### DIFF
--- a/server.js
+++ b/server.js
@@ -476,7 +476,34 @@ function createDefaultUser(pass) {
     isModerator: true,
     needsBouille: true, // Force editbouille on first login
     kikoozLog: [],      // Entries displayed in box.KikoozLog (/ft/log)
+    userLog: [],        // Entries displayed in "Mon historique" (/do/onident <ul>)
+    hasWelcomeUserLog: false,
   };
+}
+
+function nowSqlTimestamp() {
+  return new Date().toISOString().replace('T', ' ').substring(0, 19);
+}
+
+function addUserHistoryEntry(user, { type = 0, content = '' } = {}) {
+  if (!user) return;
+  if (!Array.isArray(user.userLog)) user.userLog = [];
+  user.userLog.unshift({
+    d: nowSqlTimestamp(),
+    t: Number(type) || 0,
+    c: String(content || ''),
+  });
+  if (user.userLog.length > 200) user.userLog.length = 200;
+}
+
+function buildUserLogXml(entries) {
+  const list = Array.isArray(entries) ? entries : [];
+  return list.map((e) => {
+    const d = escapeXml(e && e.d ? e.d : '');
+    const t = Number(e && e.t);
+    const c = escapeXml(e && e.c ? e.c : '');
+    return `<l d="${d}" t="${Number.isFinite(t) ? t : 0}">${c}</l>`;
+  }).join('');
 }
 
 function normalizeUsername(raw) {
@@ -1377,7 +1404,7 @@ app.get('/do/onident', (req, res) => {
   user.items = withDefaultPens(user.items);
   const items = user.items.join(',');
   const myPref = user.prefs || '';
-  const now = new Date().toISOString().replace('T', ' ').substring(0, 19);
+  const now = nowSqlTimestamp();
   const currentUsername = auth.username || '';
   const allowModeration = user.isModerator && !isDebugNotUser(currentUsername);
   const modAttr = allowModeration ? ' m="1" a="1"' : '';
@@ -1390,7 +1417,8 @@ app.get('/do/onident', (req, res) => {
     user.needsBouille = false; // Only force once per session
   }
 
-  const xml = `<r k="${user.kikooz}" p="${now}" i="${items}"${modAttr}${fAttr}><mp><![CDATA[${myPref}]]></mp><ul><!--empty--></ul><sl><!--empty--></sl><bl>${buildBouilleListXml()}</bl></r>`;
+  const userLogXml = buildUserLogXml(user.userLog);
+  const xml = `<r k="${user.kikooz}" p="${now}" i="${items}"${modAttr}${fAttr}><mp><![CDATA[${myPref}]]></mp><ul>${userLogXml}</ul><sl><!--empty--></sl><bl>${buildBouilleListXml()}</bl></r>`;
 
   res.type('text/xml').send(xml);
 });
@@ -2821,10 +2849,19 @@ function handleCBeeMessage(socket, rawXml) {
             prefs: '',
             isModerator: !isDebugNotUser(effectiveLogin),
             kikoozLog: [],
+            userLog: [],
+            hasWelcomeUserLog: false,
           };
       }
 
       const user = users[effectiveLogin];
+      if (user.hasWelcomeUserLog !== true) {
+        addUserHistoryEntry(user, {
+          type: 0,
+          content: 'Bienvenue sur Frutiparc ! Ton compte vient d’être créé.',
+        });
+        user.hasWelcomeUserLog = true;
+      }
 
       // Success: send ident response with user data
       client.username = effectiveLogin;


### PR DESCRIPTION
### Motivation
- Permettre d’afficher dans la fenêtre "Mon historique" un événement de création/accueil lors de la première connexion d’un compte afin que l’utilisateur voie immédiatement une entrée de bienvenue.
- Rendre l’historique utilisateur persistant côté serveur et sérialisable vers le XML attendu par le client SWF (`/do/onident`).

### Description
- Ajout de la propriété `userLog` et du flag `hasWelcomeUserLog` dans la structure utilisateur par défaut pour stocker les entrées d’historique et éviter les doublons. (`server.js`).
- Ajout des helpers `nowSqlTimestamp()`, `addUserHistoryEntry()` et `buildUserLogXml()` pour créer des timestamps, insérer des entrées limitées à 200 éléments et sérialiser les entrées en nœuds `<l>` XML. (`server.js`).
- Remplacement du `<ul><!--empty--></ul>` statique dans la réponse de l’endpoint `/do/onident` par le XML construit à partir de `user.userLog` afin que le client reçoive et affiche l’historique. (`server.js`).
- Lors du traitement CBee `ident`, si le compte vient d’être créé (ou n’a pas encore reçu l’événement), on ajoute automatiquement une entrée de type bienvenue et on marque `hasWelcomeUserLog` pour ne l’ajouter qu’une fois. (`server.js`).

### Testing
- Vérification statique du fichier serveur avec `node --check server.js`, résultat : OK.
- Aucun test automatisé supplémentaire présent dans le dépôt n’a été exécuté.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3feb65fd48320ba9d0d600221b204)