### PR TITLE
Add per-user history (`userLog`) and expose it via `/do/onident`; add welcome entry on account creation

### DIFF
--- a/server.js
+++ b/server.js
@@ -476,7 +476,34 @@ function createDefaultUser(pass) {
     isModerator: true,
     needsBouille: true, // Force editbouille on first login
     kikoozLog: [],      // Entries displayed in box.KikoozLog (/ft/log)
+    userLog: [],        // Entries displayed in "Mon historique" (/do/onident <ul>)
+    hasWelcomeUserLog: false,
   };
+}
+
+function nowSqlTimestamp() {
+  return new Date().toISOString().replace('T', ' ').substring(0, 19);
+}
+
+function addUserHistoryEntry(user, { type = 1, content = '' } = {}) {
+  if (!user) return;
+  if (!Array.isArray(user.userLog)) user.userLog = [];
+  user.userLog.unshift({
+    d: nowSqlTimestamp(),
+    t: Number(type) || 1,
+    c: String(content || ''),
+  });
+  if (user.userLog.length > 200) user.userLog.length = 200;
+}
+
+function buildUserLogXml(entries) {
+  const list = Array.isArray(entries) ? entries : [];
+  return list.map((e) => {
+    const d = escapeXml(e && e.d ? e.d : '');
+    const t = Number(e && e.t);
+    const c = escapeXml(e && e.c ? e.c : '');
+    return `<l d="${d}" t="${Number.isFinite(t) && t > 0 ? t : 1}">${c}</l>`;
+  }).join('');
 }
 
 function normalizeUsername(raw) {
@@ -1377,7 +1404,7 @@ app.get('/do/onident', (req, res) => {
   user.items = withDefaultPens(user.items);
   const items = user.items.join(',');
   const myPref = user.prefs || '';
-  const now = new Date().toISOString().replace('T', ' ').substring(0, 19);
+  const now = nowSqlTimestamp();
   const currentUsername = auth.username || '';
   const allowModeration = user.isModerator && !isDebugNotUser(currentUsername);
   const modAttr = allowModeration ? ' m="1" a="1"' : '';
@@ -1390,7 +1417,8 @@ app.get('/do/onident', (req, res) => {
     user.needsBouille = false; // Only force once per session
   }
 
-  const xml = `<r k="${user.kikooz}" p="${now}" i="${items}"${modAttr}${fAttr}><mp><![CDATA[${myPref}]]></mp><ul><!--empty--></ul><sl><!--empty--></sl><bl>${buildBouilleListXml()}</bl></r>`;
+  const userLogXml = buildUserLogXml(user.userLog);
+  const xml = `<r k="${user.kikooz}" p="${now}" i="${items}"${modAttr}${fAttr}><mp><![CDATA[${myPref}]]></mp><ul>${userLogXml}</ul><sl><!--empty--></sl><bl>${buildBouilleListXml()}</bl></r>`;
 
   res.type('text/xml').send(xml);
 });
@@ -2821,10 +2849,20 @@ function handleCBeeMessage(socket, rawXml) {
             prefs: '',
             isModerator: !isDebugNotUser(effectiveLogin),
             kikoozLog: [],
+            userLog: [],
+            hasWelcomeUserLog: false,
           };
       }
 
       const user = users[effectiveLogin];
+      if (user.hasWelcomeUserLog !== true) {
+        addUserHistoryEntry(user, {
+          // type=1 = icône d'évènement standard (évite le type 0 qui ne fixe pas d'image)
+          type: 1,
+          content: 'Bienvenue sur Frutiparc ! Ton compte vient d’être créé.',
+        });
+        user.hasWelcomeUserLog = true;
+      }
 
       // Success: send ident response with user data
       client.username = effectiveLogin;


### PR DESCRIPTION
### Motivation
- Introduce a per-user history feed so the client can show a "Mon historique" list and server-side events can be recorded. 
- Ensure new accounts receive a default welcome history entry so first-time users get an informative event. 
- Keep the event store bounded to avoid uncontrolled growth and use a consistent SQL-like timestamp format for events.

### Description
- Added `userLog` and `hasWelcomeUserLog` to default user objects in `createDefaultUser` and the CBee auto-created user branch. 
- Implemented `nowSqlTimestamp()`, `addUserHistoryEntry()` (with truncation to 200 entries) and `buildUserLogXml()` to create and serialize history entries. 
- Included the serialized `userLog` in the `/do/onident` XML response by replacing the previous empty `<ul><!--empty--></ul>` with `<ul>${userLogXml}</ul>` and switched to `nowSqlTimestamp()` for the `p` attribute. 
- On auto-creation of a user in the CBee login flow, add a welcome history entry if `hasWelcomeUserLog` is not true and mark it as set.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3feb65fd48320ba9d0d600221b204)