### PR TITLE
Persist and deliver user history (userLog); mark new client-side entries correctly

### DIFF
--- a/frutiparc/MeMng.as
+++ b/frutiparc/MeMng.as
@@ -180,10 +180,8 @@ class MeMng{
 		obj - object - Object containing properties content and time, flNew is added
 	*/
 	function addUserLog(obj){
-		if(obj.time > this.previousTime){
-			obj.flNew = true;
-		}else{
-			obj.flNew = false;
+		if(obj.flNew == undefined){
+			obj.flNew = (obj.time >= this.previousTime);
 		}
 		if(obj.flNew){
 			this.digitalScreen.unSleep(3);

--- a/frutiparc/listener/main.as
+++ b/frutiparc/listener/main.as
@@ -274,7 +274,7 @@
 
 							if(c.nodeName != "l") continue;
 
-							_global.me.addUserLog({time: c.attributes.d,type: Number(c.attributes.t),content: c.firstChild.nodeValue.toString()});
+							_global.me.addUserLog({time: c.attributes.d,type: Number(c.attributes.t),content: c.firstChild.nodeValue.toString(),flNew: false});
 
 						}
 
@@ -610,7 +610,7 @@
 
 	static function onNewUserLog(node){
 
-		_global.me.addUserLog({time: node.attributes.date,type: node.attributes.type,content: node.firstChild.nodeValue.toString()});
+		_global.me.addUserLog({time: node.attributes.date,type: Number(node.attributes.type),content: node.firstChild.nodeValue.toString(),flNew: true});
 
 	}
 
@@ -1219,6 +1219,5 @@ _global.fKillAll = function(str){
 };
 
 */
-
 
 

--- a/server.js
+++ b/server.js
@@ -476,7 +476,34 @@ function createDefaultUser(pass) {
     isModerator: true,
     needsBouille: true, // Force editbouille on first login
     kikoozLog: [],      // Entries displayed in box.KikoozLog (/ft/log)
+    userLog: [],        // Entries displayed in "Mon historique" (/do/onident <ul>)
+    hasWelcomeUserLog: false,
   };
+}
+
+function nowSqlTimestamp() {
+  return new Date().toISOString().replace('T', ' ').substring(0, 19);
+}
+
+function addUserHistoryEntry(user, { type = 1, content = '' } = {}) {
+  if (!user) return;
+  if (!Array.isArray(user.userLog)) user.userLog = [];
+  user.userLog.unshift({
+    d: nowSqlTimestamp(),
+    t: Number(type) || 1,
+    c: String(content || ''),
+  });
+  if (user.userLog.length > 200) user.userLog.length = 200;
+}
+
+function buildUserLogXml(entries) {
+  const list = Array.isArray(entries) ? entries : [];
+  return list.map((e) => {
+    const d = escapeXml(e && e.d ? e.d : '');
+    const t = Number(e && e.t);
+    const c = escapeXml(e && e.c ? e.c : '');
+    return `<l d="${d}" t="${Number.isFinite(t) && t > 0 ? t : 1}">${c}</l>`;
+  }).join('');
 }
 
 function normalizeUsername(raw) {
@@ -1377,7 +1404,7 @@ app.get('/do/onident', (req, res) => {
   user.items = withDefaultPens(user.items);
   const items = user.items.join(',');
   const myPref = user.prefs || '';
-  const now = new Date().toISOString().replace('T', ' ').substring(0, 19);
+  const now = nowSqlTimestamp();
   const currentUsername = auth.username || '';
   const allowModeration = user.isModerator && !isDebugNotUser(currentUsername);
   const modAttr = allowModeration ? ' m="1" a="1"' : '';
@@ -1390,7 +1417,8 @@ app.get('/do/onident', (req, res) => {
     user.needsBouille = false; // Only force once per session
   }
 
-  const xml = `<r k="${user.kikooz}" p="${now}" i="${items}"${modAttr}${fAttr}><mp><![CDATA[${myPref}]]></mp><ul><!--empty--></ul><sl><!--empty--></sl><bl>${buildBouilleListXml()}</bl></r>`;
+  const userLogXml = buildUserLogXml(user.userLog);
+  const xml = `<r k="${user.kikooz}" p="${now}" i="${items}"${modAttr}${fAttr}><mp><![CDATA[${myPref}]]></mp><ul>${userLogXml}</ul><sl><!--empty--></sl><bl>${buildBouilleListXml()}</bl></r>`;
 
   res.type('text/xml').send(xml);
 });
@@ -2821,10 +2849,21 @@ function handleCBeeMessage(socket, rawXml) {
             prefs: '',
             isModerator: !isDebugNotUser(effectiveLogin),
             kikoozLog: [],
+            userLog: [],
+            hasWelcomeUserLog: false,
           };
       }
 
       const user = users[effectiveLogin];
+      let welcomeLogEntry = null;
+      if (user.hasWelcomeUserLog !== true) {
+        addUserHistoryEntry(user, {
+          type: 8,
+          content: "Bienvenue sur Frutiparc Revival ! Tu n'as donc rien de mieux à faire ?!",
+        });
+        user.hasWelcomeUserLog = true;
+        welcomeLogEntry = user.userLog[0] || null;
+      }
 
       // Success: send ident response with user data
       client.username = effectiveLogin;
@@ -2832,6 +2871,12 @@ function handleCBeeMessage(socket, rawXml) {
       client.logged = true;
 
       sendToClient(socket, `<${CMD.ident} l="${effectiveLogin}" x="${user.xp}" f="${bouilleOf(user)}" />`);
+      if (welcomeLogEntry) {
+        sendToClient(
+          socket,
+          `<${CMD.newuserlog} date="${escapeXml(welcomeLogEntry.d || nowSqlTimestamp())}" type="${escapeXml(String(welcomeLogEntry.t || 8))}">${escapeXml(welcomeLogEntry.c || '')}</${CMD.newuserlog}>`,
+        );
+      }
       console.log(`[CBee]  User "${effectiveLogin}" logged in (sid=${sid})`);
       break;
     }


### PR DESCRIPTION
### Motivation

- Persist a per-user history (`userLog`) server-side and include it in the identification response so the client can show "Mon historique" after login.
- Send a welcome history entry on first login so new users see an initial message in their history.
- Ensure client-side handling of history entries treats server-provided entries as not-new and real-time entries as new, avoiding wrong "new" flags.

### Description

- Server: add `userLog` and `hasWelcomeUserLog` fields to default user data and to auto-created users in CBee login handling.
- Server: add helper functions `nowSqlTimestamp()`, `addUserHistoryEntry(user, {type,content})`, and `buildUserLogXml(entries)`; cap stored history to 200 items and normalize/escape values. 
- Server: include built `<ul>...</ul>` with user history in the `/do/onident` XML response via `buildUserLogXml`. 
- Server: on first login add a welcome history entry via `addUserHistoryEntry` and send a `newuserlog` message to the client if created. 
- Client (AS2): change `MeMng.addUserLog` to only compute `flNew` when it is not provided by the caller, using `obj.time >= this.previousTime` as the default rule; keep waking the digital screen when `flNew` is true. 
- Client (listener): when parsing server-provided user log list, pass `flNew: false` for existing entries; when receiving `onNewUserLog` set `type` to `Number(...)` and pass `flNew: true` for real-time entries.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3feb65fd48320ba9d0d600221b204)