### PR TITLE
Persist user activity logs and propagate 'Mon historique' to client; mark new entries correctly

### DIFF
--- a/frutiparc/MeMng.as
+++ b/frutiparc/MeMng.as
@@ -180,10 +180,8 @@ class MeMng{
 		obj - object - Object containing properties content and time, flNew is added
 	*/
 	function addUserLog(obj){
-		if(obj.time > this.previousTime){
-			obj.flNew = true;
-		}else{
-			obj.flNew = false;
+		if(obj.flNew == undefined){
+			obj.flNew = (obj.time >= this.previousTime);
 		}
 		if(obj.flNew){
 			this.digitalScreen.unSleep(3);

--- a/frutiparc/listener/main.as
+++ b/frutiparc/listener/main.as
@@ -610,7 +610,7 @@
 
 	static function onNewUserLog(node){
 
-		_global.me.addUserLog({time: node.attributes.date,type: node.attributes.type,content: node.firstChild.nodeValue.toString()});
+		_global.me.addUserLog({time: node.attributes.date,type: Number(node.attributes.type),content: node.firstChild.nodeValue.toString(),flNew: true});
 
 	}
 
@@ -1219,6 +1219,4 @@ _global.fKillAll = function(str){
 };
 
 */
-
-
 

--- a/server.js
+++ b/server.js
@@ -476,7 +476,34 @@ function createDefaultUser(pass) {
     isModerator: true,
     needsBouille: true, // Force editbouille on first login
     kikoozLog: [],      // Entries displayed in box.KikoozLog (/ft/log)
+    userLog: [],        // Entries displayed in "Mon historique" (/do/onident <ul>)
+    hasWelcomeUserLog: false,
   };
+}
+
+function nowSqlTimestamp() {
+  return new Date().toISOString().replace('T', ' ').substring(0, 19);
+}
+
+function addUserHistoryEntry(user, { type = 1, content = '' } = {}) {
+  if (!user) return;
+  if (!Array.isArray(user.userLog)) user.userLog = [];
+  user.userLog.unshift({
+    d: nowSqlTimestamp(),
+    t: Number(type) || 1,
+    c: String(content || ''),
+  });
+  if (user.userLog.length > 200) user.userLog.length = 200;
+}
+
+function buildUserLogXml(entries) {
+  const list = Array.isArray(entries) ? entries : [];
+  return list.map((e) => {
+    const d = escapeXml(e && e.d ? e.d : '');
+    const t = Number(e && e.t);
+    const c = escapeXml(e && e.c ? e.c : '');
+    return `<l d="${d}" t="${Number.isFinite(t) && t > 0 ? t : 1}">${c}</l>`;
+  }).join('');
 }
 
 function normalizeUsername(raw) {
@@ -1377,7 +1404,7 @@ app.get('/do/onident', (req, res) => {
   user.items = withDefaultPens(user.items);
   const items = user.items.join(',');
   const myPref = user.prefs || '';
-  const now = new Date().toISOString().replace('T', ' ').substring(0, 19);
+  const now = nowSqlTimestamp();
   const currentUsername = auth.username || '';
   const allowModeration = user.isModerator && !isDebugNotUser(currentUsername);
   const modAttr = allowModeration ? ' m="1" a="1"' : '';
@@ -1390,7 +1417,8 @@ app.get('/do/onident', (req, res) => {
     user.needsBouille = false; // Only force once per session
   }
 
-  const xml = `<r k="${user.kikooz}" p="${now}" i="${items}"${modAttr}${fAttr}><mp><![CDATA[${myPref}]]></mp><ul><!--empty--></ul><sl><!--empty--></sl><bl>${buildBouilleListXml()}</bl></r>`;
+  const userLogXml = buildUserLogXml(user.userLog);
+  const xml = `<r k="${user.kikooz}" p="${now}" i="${items}"${modAttr}${fAttr}><mp><![CDATA[${myPref}]]></mp><ul>${userLogXml}</ul><sl><!--empty--></sl><bl>${buildBouilleListXml()}</bl></r>`;
 
   res.type('text/xml').send(xml);
 });
@@ -2821,10 +2849,19 @@ function handleCBeeMessage(socket, rawXml) {
             prefs: '',
             isModerator: !isDebugNotUser(effectiveLogin),
             kikoozLog: [],
+            userLog: [],
+            hasWelcomeUserLog: false,
           };
       }
 
       const user = users[effectiveLogin];
+      if (user.hasWelcomeUserLog !== true) {
+        addUserHistoryEntry(user, {
+          type: 1,
+          content: "Bienvenue sur Frutiparc Revival ! Tu n'as donc rien de mieux à faire ?!",
+        });
+        user.hasWelcomeUserLog = true;
+      }
 
       // Success: send ident response with user data
       client.username = effectiveLogin;


### PR DESCRIPTION
### Motivation

- Persist per-user "Mon historique" entries on the server and include them in the post-ident response so the client can display history after login. 
- Ensure newly received log entries are marked correctly on the client so the UI can highlight/sleep/un-sleep appropriately.

### Description

- Added server-side structures and helpers in `server.js`: `nowSqlTimestamp`, `addUserHistoryEntry`, and `buildUserLogXml` to store, trim (max 200), and serialize user history entries.
- Included `userLog` and `hasWelcomeUserLog` in default user records and in auto-created users, and inject a welcome history entry on first CBee login using `addUserHistoryEntry`.
- Changed the `/do/onident` response to include serialized user log XML in the `<ul>` element instead of `<!--empty-->` so the client receives history on identification, and replaced inline timestamp generation with `nowSqlTimestamp`.
- Client-side changes: updated `MeMng.addUserLog` to only compute `obj.flNew` when it is undefined and compute it using `obj.time >= this.previousTime`; updated listener to call `addUserLog` with `type` coerced to `Number` and `flNew: true` in `onNewUserLog`.

### Testing

- Ran the project's automated tests via `npm test` and linters, which completed successfully.
- Performed a server smoke test by starting `node server.js` and simulating a CBee login, which returned an `<r ...><ul>...</ul>` ident response containing the serialized user log entries. 
- Verified that a newly received user-log event triggers `addUserLog` with `flNew:true` from the listener and that `MeMng.addUserLog` sets `flNew` only if undefined and calls `digitalScreen.unSleep` for new entries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3feb65fd48320ba9d0d600221b204)