### PR TITLE
Support persistent user history (userLog) and honor 'new' flags

### DIFF
--- a/frutiparc/MeMng.as
+++ b/frutiparc/MeMng.as
@@ -180,10 +180,8 @@ class MeMng{
 		obj - object - Object containing properties content and time, flNew is added
 	*/
 	function addUserLog(obj){
-		if(obj.time > this.previousTime){
-			obj.flNew = true;
-		}else{
-			obj.flNew = false;
+		if(obj.flNew == undefined){
+			obj.flNew = (obj.time >= this.previousTime);
 		}
 		if(obj.flNew){
 			this.digitalScreen.unSleep(3);

--- a/frutiparc/listener/main.as
+++ b/frutiparc/listener/main.as
@@ -274,7 +274,7 @@
 
 							if(c.nodeName != "l") continue;
 
-							_global.me.addUserLog({time: c.attributes.d,type: Number(c.attributes.t),content: c.firstChild.nodeValue.toString()});
+							_global.me.addUserLog({time: c.attributes.d,type: Number(c.attributes.t),content: c.firstChild.nodeValue.toString(),flNew: (c.attributes.n=="1")?true:undefined});
 
 						}
 
@@ -610,7 +610,7 @@
 
 	static function onNewUserLog(node){
 
-		_global.me.addUserLog({time: node.attributes.date,type: node.attributes.type,content: node.firstChild.nodeValue.toString()});
+		_global.me.addUserLog({time: node.attributes.date,type: Number(node.attributes.type),content: node.firstChild.nodeValue.toString(),flNew: true});
 
 	}
 
@@ -1219,6 +1219,3 @@ _global.fKillAll = function(str){
 };
 
 */
-
-
-

--- a/server.js
+++ b/server.js
@@ -476,7 +476,37 @@ function createDefaultUser(pass) {
     isModerator: true,
     needsBouille: true, // Force editbouille on first login
     kikoozLog: [],      // Entries displayed in box.KikoozLog (/ft/log)
+    userLog: [],        // Entries displayed in "Mon historique" (/do/onident <ul>)
+    hasWelcomeUserLog: false,
   };
+}
+
+function nowSqlTimestamp() {
+  return new Date().toISOString().replace('T', ' ').substring(0, 19);
+}
+
+function addUserHistoryEntry(user, { type = 1, content = '', flNew = false } = {}) {
+  if (!user) return;
+  if (!Array.isArray(user.userLog)) user.userLog = [];
+  const entry = {
+    d: nowSqlTimestamp(),
+    t: Number(type) || 1,
+    c: String(content || ''),
+  };
+  if (flNew) entry.n = 1;
+  user.userLog.unshift(entry);
+  if (user.userLog.length > 200) user.userLog.length = 200;
+}
+
+function buildUserLogXml(entries) {
+  const list = Array.isArray(entries) ? entries : [];
+  return list.map((e) => {
+    const d = escapeXml(e && e.d ? e.d : '');
+    const t = Number(e && e.t);
+    const c = escapeXml(e && e.c ? e.c : '');
+    const n = (e && Number(e.n) === 1) ? ' n="1"' : '';
+    return `<l d="${d}" t="${Number.isFinite(t) && t > 0 ? t : 1}"${n}>${c}</l>`;
+  }).join('');
 }
 
 function normalizeUsername(raw) {
@@ -1377,7 +1407,7 @@ app.get('/do/onident', (req, res) => {
   user.items = withDefaultPens(user.items);
   const items = user.items.join(',');
   const myPref = user.prefs || '';
-  const now = new Date().toISOString().replace('T', ' ').substring(0, 19);
+  const now = nowSqlTimestamp();
   const currentUsername = auth.username || '';
   const allowModeration = user.isModerator && !isDebugNotUser(currentUsername);
   const modAttr = allowModeration ? ' m="1" a="1"' : '';
@@ -1390,7 +1420,13 @@ app.get('/do/onident', (req, res) => {
     user.needsBouille = false; // Only force once per session
   }
 
-  const xml = `<r k="${user.kikooz}" p="${now}" i="${items}"${modAttr}${fAttr}><mp><![CDATA[${myPref}]]></mp><ul><!--empty--></ul><sl><!--empty--></sl><bl>${buildBouilleListXml()}</bl></r>`;
+  const userLogXml = buildUserLogXml(user.userLog);
+  const xml = `<r k="${user.kikooz}" p="${now}" i="${items}"${modAttr}${fAttr}><mp><![CDATA[${myPref}]]></mp><ul>${userLogXml}</ul><sl><!--empty--></sl><bl>${buildBouilleListXml()}</bl></r>`;
+  if (Array.isArray(user.userLog)) {
+    for (let i = 0; i < user.userLog.length; i += 1) {
+      if (user.userLog[i] && Number(user.userLog[i].n) === 1) delete user.userLog[i].n;
+    }
+  }
 
   res.type('text/xml').send(xml);
 });
@@ -2821,10 +2857,20 @@ function handleCBeeMessage(socket, rawXml) {
             prefs: '',
             isModerator: !isDebugNotUser(effectiveLogin),
             kikoozLog: [],
+            userLog: [],
+            hasWelcomeUserLog: false,
           };
       }
 
       const user = users[effectiveLogin];
+      if (user.hasWelcomeUserLog !== true) {
+        addUserHistoryEntry(user, {
+          type: 1,
+          content: "Bienvenue sur Frutiparc Revival ! Tu n'as donc rien de mieux à faire ?!",
+          flNew: true,
+        });
+        user.hasWelcomeUserLog = true;
+      }
 
       // Success: send ident response with user data
       client.username = effectiveLogin;


### PR DESCRIPTION
### Motivation

- Persist and transmit per-user history entries so the client can populate "Mon historique" without an empty placeholder.
- Allow entries to be flagged as new so the client UI can react (wake `digitalScreen`) only for genuinely new items.
- Auto-insert a welcome history entry for newly created users to guide first-time sessions.

### Description

- Added persistent `userLog` and `hasWelcomeUserLog` fields to default/new user records and included `userLog` initialization in CBee login handling. 
- Implemented `nowSqlTimestamp()`, `addUserHistoryEntry()` to append bounded history entries, and `buildUserLogXml()` to serialize history as `<l d="..." t="..." [n="1"]>...</l>` for the `/do/onident` response. 
- Updated `/do/onident` to embed the user's `userLog` XML and to remove the transient `n` (new) flag after sending. 
- On CBee login, add a one-time welcome history entry via `addUserHistoryEntry()` and mark it as shown with `hasWelcomeUserLog`. 
- Client-side: when parsing `ul` entries in `listener/main.as`, forward the `n` attribute as `flNew` to the manager; `onNewUserLog` now passes `flNew: true` and coerces `type` to `Number`. 
- `MeMng.addUserLog` adjusted to only compute `flNew` when the caller didn't provide it, using `obj.time >= this.previousTime` when undefined, preserving caller-specified `flNew` values and triggering `digitalScreen.unSleep()` for new entries.

### Testing

- Ran the existing automated test suite via `npm test`, and it completed successfully. 
- No new automated tests were added for `userLog` serialization or CBee login welcome entry in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3feb65fd48320ba9d0d600221b204)