### PR TITLE
Add persisted user/site history, welcome entries and MeMng digital wake buffering

### DIFF
--- a/frutiparc/MeMng.as
+++ b/frutiparc/MeMng.as
@@ -19,6 +19,8 @@ class MeMng{
 	var siteLog:Array;
 	var previousTime:String;
 	var digitalScreen:MovieClip;
+	var pendingDigitalWake:Array;
+	var pendingDigitalWakeInterval:Number;
 	var flMode:Boolean;
   var flAnimator:Boolean;
   var bouilleList:Array; // [] = {name: "",bouille: ""}
@@ -48,6 +50,8 @@ class MeMng{
 		this.$kikooz = 0;
 		this.userLog = new Array();
 		this.siteLog = new Array();
+		this.pendingDigitalWake = new Array();
+		this.pendingDigitalWakeInterval = undefined;
 		this.flMuted = false;
 		this.flMode = false;
 		
@@ -180,13 +184,11 @@ class MeMng{
 		obj - object - Object containing properties content and time, flNew is added
 	*/
 	function addUserLog(obj){
-		if(obj.time > this.previousTime){
-			obj.flNew = true;
-		}else{
-			obj.flNew = false;
+		if(obj.flNew == undefined){
+			obj.flNew = (obj.time >= this.previousTime);
 		}
 		if(obj.flNew){
-			this.digitalScreen.unSleep(3);
+			this.requestDigitalWake(3);
 		}
 		this.userLog.pushAt(0,obj);
 		this.broadcastMessage("userLog",this.userLog);
@@ -201,16 +203,35 @@ class MeMng{
 	}
 	
 	function addSiteLog(obj){
-		if(obj.time > this.previousTime){
-			obj.flNew = true;
-		}else{
-			obj.flNew = false;
+		if(obj.flNew == undefined){
+			obj.flNew = (obj.time > this.previousTime);
 		}
 		if(obj.flNew){
-			this.digitalScreen.unSleep(4);
+			this.requestDigitalWake(4);
 		}
 		this.siteLog.pushAt(0,obj);
 		this.broadcastMessage("siteLog",this.siteLog);
+	}
+
+	function requestDigitalWake(id){
+		if(this.digitalScreen != undefined){
+			this.digitalScreen.unSleep(id);
+			return;
+		}
+		this.pendingDigitalWake.push(id);
+		if(this.pendingDigitalWakeInterval == undefined){
+			this.pendingDigitalWakeInterval = setInterval(this,"flushPendingDigitalWake",250);
+		}
+	}
+
+	function flushPendingDigitalWake(){
+		if(this.digitalScreen == undefined) return;
+		clearInterval(this.pendingDigitalWakeInterval);
+		this.pendingDigitalWakeInterval = undefined;
+		for(var i=0;i<this.pendingDigitalWake.length;i++){
+			this.digitalScreen.unSleep(this.pendingDigitalWake[i]);
+		}
+		this.pendingDigitalWake = new Array();
 	}
 	
 	function onDisplaySiteLog(){

--- a/frutiparc/listener/main.as
+++ b/frutiparc/listener/main.as
@@ -274,7 +274,7 @@
 
 							if(c.nodeName != "l") continue;
 
-							_global.me.addUserLog({time: c.attributes.d,type: Number(c.attributes.t),content: c.firstChild.nodeValue.toString()});
+							_global.me.addUserLog({time: c.attributes.d,type: Number(c.attributes.t),content: c.firstChild.nodeValue.toString(),flNew: (c.attributes.n=="1")?true:undefined});
 
 						}
 
@@ -288,13 +288,13 @@
 
 						_global.me.emptySiteLog();
 
-						for(var c=n.firstChild;c.nodeType>0;c=c.nextSibling){
+							for(var c=n.firstChild;c.nodeType>0;c=c.nextSibling){
 
-							if(c.nodeName != "l") continue;
+								if(c.nodeName != "l") continue;
 
-							_global.me.addSiteLog({time: c.attributes.d,type: Number(c.attributes.t),content: c.firstChild.nodeValue.toString()});
+								_global.me.addSiteLog({time: c.attributes.d,type: Number(c.attributes.t),content: c.firstChild.nodeValue.toString(),flNew: (c.attributes.n=="1")?true:undefined});
 
-						}
+							}
 
 						break;
 
@@ -610,7 +610,7 @@
 
 	static function onNewUserLog(node){
 
-		_global.me.addUserLog({time: node.attributes.date,type: node.attributes.type,content: node.firstChild.nodeValue.toString()});
+		_global.me.addUserLog({time: node.attributes.date,type: Number(node.attributes.type),content: node.firstChild.nodeValue.toString(),flNew: true});
 
 	}
 
@@ -1219,6 +1219,3 @@ _global.fKillAll = function(str){
 };
 
 */
-
-
-

--- a/server.js
+++ b/server.js
@@ -476,7 +476,52 @@ function createDefaultUser(pass) {
     isModerator: true,
     needsBouille: true, // Force editbouille on first login
     kikoozLog: [],      // Entries displayed in box.KikoozLog (/ft/log)
+    userLog: [],        // Entries displayed in "Mon historique" (/do/onident <ul>)
+    siteLog: [],        // Entries displayed in "Evènements" (/do/onident <sl>)
+    hasWelcomeUserLog: false,
+    hasWelcomeSiteLog: false,
   };
+}
+
+function nowSqlTimestamp() {
+  return new Date().toISOString().replace('T', ' ').substring(0, 19);
+}
+
+function addUserHistoryEntry(user, { type = 1, content = '', flNew = false } = {}) {
+  if (!user) return;
+  if (!Array.isArray(user.userLog)) user.userLog = [];
+  const entry = {
+    d: nowSqlTimestamp(),
+    t: Number(type) || 1,
+    c: String(content || ''),
+  };
+  if (flNew) entry.n = 1;
+  user.userLog.unshift(entry);
+  if (user.userLog.length > 200) user.userLog.length = 200;
+}
+
+function addSiteHistoryEntry(user, { type = 1, content = '', flNew = false } = {}) {
+  if (!user) return;
+  if (!Array.isArray(user.siteLog)) user.siteLog = [];
+  const entry = {
+    d: nowSqlTimestamp(),
+    t: Number(type) || 1,
+    c: String(content || ''),
+  };
+  if (flNew) entry.n = 1;
+  user.siteLog.unshift(entry);
+  if (user.siteLog.length > 200) user.siteLog.length = 200;
+}
+
+function buildUserLogXml(entries) {
+  const list = Array.isArray(entries) ? entries : [];
+  return list.map((e) => {
+    const d = escapeXml(e && e.d ? e.d : '');
+    const t = Number(e && e.t);
+    const c = escapeXml(e && e.c ? e.c : '');
+    const n = (e && Number(e.n) === 1) ? ' n="1"' : '';
+    return `<l d="${d}" t="${Number.isFinite(t) && t > 0 ? t : 1}"${n}>${c}</l>`;
+  }).join('');
 }
 
 function normalizeUsername(raw) {
@@ -1377,7 +1422,7 @@ app.get('/do/onident', (req, res) => {
   user.items = withDefaultPens(user.items);
   const items = user.items.join(',');
   const myPref = user.prefs || '';
-  const now = new Date().toISOString().replace('T', ' ').substring(0, 19);
+  const now = nowSqlTimestamp();
   const currentUsername = auth.username || '';
   const allowModeration = user.isModerator && !isDebugNotUser(currentUsername);
   const modAttr = allowModeration ? ' m="1" a="1"' : '';
@@ -1390,7 +1435,17 @@ app.get('/do/onident', (req, res) => {
     user.needsBouille = false; // Only force once per session
   }
 
-  const xml = `<r k="${user.kikooz}" p="${now}" i="${items}"${modAttr}${fAttr}><mp><![CDATA[${myPref}]]></mp><ul><!--empty--></ul><sl><!--empty--></sl><bl>${buildBouilleListXml()}</bl></r>`;
+  const userLogXml = buildUserLogXml(user.userLog);
+  const siteLogXml = buildUserLogXml(user.siteLog);
+  const xml = `<r k="${user.kikooz}" p="${now}" i="${items}"${modAttr}${fAttr}><mp><![CDATA[${myPref}]]></mp><ul>${userLogXml}</ul><sl>${siteLogXml}</sl><bl>${buildBouilleListXml()}</bl></r>`;
+  const clearTransientNewFlag = (arr) => {
+    if (!Array.isArray(arr)) return;
+    for (let i = 0; i < arr.length; i += 1) {
+      if (arr[i] && Number(arr[i].n) === 1) delete arr[i].n;
+    }
+  };
+  clearTransientNewFlag(user.userLog);
+  clearTransientNewFlag(user.siteLog);
 
   res.type('text/xml').send(xml);
 });
@@ -2821,10 +2876,30 @@ function handleCBeeMessage(socket, rawXml) {
             prefs: '',
             isModerator: !isDebugNotUser(effectiveLogin),
             kikoozLog: [],
+            userLog: [],
+            siteLog: [],
+            hasWelcomeUserLog: false,
+            hasWelcomeSiteLog: false,
           };
       }
 
       const user = users[effectiveLogin];
+      if (user.hasWelcomeUserLog !== true) {
+        addUserHistoryEntry(user, {
+          type: 1,
+          content: "Bienvenue sur Frutiparc Revival ! Tu n'as donc rien de mieux à faire ?!",
+          flNew: true,
+        });
+        user.hasWelcomeUserLog = true;
+      }
+      if (user.hasWelcomeSiteLog !== true) {
+        addSiteHistoryEntry(user, {
+          type: 1,
+          content: "Évènement: ton compte Frutiparc Revival vient d'être activé.",
+          flNew: true,
+        });
+        user.hasWelcomeSiteLog = true;
+      }
 
       // Success: send ident response with user data
       client.username = effectiveLogin;


### PR DESCRIPTION
### Motivation

- Provide persistent per-user "Mon historique" and "Evènements" logs on the server and surface them to the client `do/onident` response. 
- Ensure the client SWF (`MeMng`) can request digital-screen wakeups even before the `digitalScreen` object is initialized. 
- Seed newly created accounts with a welcome user and site history entry so first-time users see initial messages.

### Description

- Server: add `userLog` and `siteLog` fields to user objects, flags `hasWelcomeUserLog` / `hasWelcomeSiteLog`, and helper functions `nowSqlTimestamp`, `addUserHistoryEntry`, `addSiteHistoryEntry`, and `buildUserLogXml` to manage and serialize history entries. 
- Server: include `<ul>` and `<sl>` XML payloads in the `/do/onident` response and clear transient `n` (new) flags after sending. 
- Server: on CBee login auto-create welcome entries for new users and mark them as shown, and ensure default user creation includes the new log structures. 
- Client AS2: extend `MeMng` with `pendingDigitalWake` queue and `pendingDigitalWakeInterval`, add `requestDigitalWake` and `flushPendingDigitalWake` to buffer `digitalScreen.unSleep` calls until `digitalScreen` exists, and update `addUserLog`/`addSiteLog` to accept an explicit `flNew` flag and to call `requestDigitalWake` instead of `digitalScreen.unSleep` directly. 
- Listener AS2: when parsing server log lists and incoming notifications, pass the `flNew` flag from XML attribute `n` (or set `true` for new incoming user logs) when calling `addUserLog`/`addSiteLog`.

### Testing

- Started the server and performed a smoke test `GET /do/onident` for an existing user and confirmed the response contains `<ul>` and `<sl>` entries serialized by `buildUserLogXml`, and the endpoint returned `200 OK`. 
- Simulated CBee login path for a newly created user and confirmed welcome entries were added to `userLog` and `siteLog` and emitted to the client on ident; no errors were observed. 
- Ran basic linting/sanity checks on the server code and AS2 changes and found no runtime exceptions in the exercised flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3feb65fd48320ba9d0d600221b204)